### PR TITLE
Set nginx client_max_body_size to 5GB and increase gunicorn timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   web:
     build: .
     entrypoint: /home/app/web/entrypoint.sh
-    command: gunicorn shifter.wsgi:application --bind 0.0.0.0:8000
+    command: gunicorn shifter.wsgi:application --bind 0.0.0.0:8000 --timeout 600
     restart: always
     volumes:
       - static:/home/app/web/static

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
+        client_max_body_size 5G;
     }
 
     location /static/ {


### PR DESCRIPTION
Fixes #34 

Increases nginxs max body size and also Gunicorns timeout to 10 minutes, might need to be larger when deployed but makes the server more exposed to certain type of attacks (e.g. slowloris)

In the future it would be nice to have some sort of upload progress bar too - something I think filepond supports but we do not implement due to how we send the request. 