### PR TITLE
No expiry in past

### DIFF
--- a/shifter/shifter_files/forms.py
+++ b/shifter/shifter_files/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.utils import timezone
+from django.core.exceptions import ValidationError
 
 from .models import FileUpload
 from .widgets import ShifterDateTimeInput
@@ -21,3 +22,14 @@ class FileUploadForm(forms.ModelForm):
         exp_date = timezone.now() + settings.DEFAULT_EXPIRY_OFFSET
         exp_date_str = exp_date.strftime(settings.DATETIME_INPUT_FORMATS[0])
         self.fields['expiry_datetime'].initial = exp_date_str
+
+    def clean_expiry_datetime(self):
+        expiry_datetime = self.cleaned_data['expiry_datetime']
+        current_datetime = timezone.now()
+
+        if expiry_datetime < current_datetime:
+            raise ValidationError(
+                "You can't upload a file with an expiry time in the past!",
+                code='expiry-time-past')
+
+        return expiry_datetime

--- a/shifter/shifter_files/forms.py
+++ b/shifter/shifter_files/forms.py
@@ -22,6 +22,8 @@ class FileUploadForm(forms.ModelForm):
         exp_date = timezone.now() + settings.DEFAULT_EXPIRY_OFFSET
         exp_date_str = exp_date.strftime(settings.DATETIME_INPUT_FORMATS[0])
         self.fields['expiry_datetime'].initial = exp_date_str
+        self.fields['expiry_datetime'].widget.attrs['min'] = timezone.now(
+        ).strftime(settings.DATETIME_INPUT_FORMATS[0])
 
     def clean_expiry_datetime(self):
         expiry_datetime = self.cleaned_data['expiry_datetime']

--- a/shifter/shifter_files/tests/test_views.py
+++ b/shifter/shifter_files/tests/test_views.py
@@ -74,6 +74,22 @@ class IndexViewTest(TestCase):
         self.assertEqual(response.url, reverse("shifter_files:file-details",
                                                args=[file_upload.file_hex]))
 
+    def test_expiry_date_in_past(self):
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        current_datetime = timezone.now()
+        expiry_datetime = current_datetime - datetime.timedelta(days=1)
+        test_file = SimpleUploadedFile(TEST_FILE_NAME, TEST_FILE_CONTENT)
+        response = client.post(reverse("shifter_files:index"), {
+            "expiry_datetime": expiry_datetime.isoformat(
+                sep=' ', timespec='minutes'),
+            "file_content": test_file
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertInHTML(("You can't upload a file with an expiry time in "
+                           "the past!"), response.content.decode())
+        self.assertEqual(FileUpload.objects.count(), 0)
+
 
 class FileDetailsViewTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Add checks so users can't set an expiry date for the past. Checks are done on both front end and back end.