### PR TITLE
Feature #114 users should be able to set their timezone

### DIFF
--- a/.env EXAMPLE
+++ b/.env EXAMPLE
@@ -7,6 +7,7 @@ DJANGO_LOG_LEVEL=INFO
 DJANGO_SUPERUSER_EMAIL=admin@mydomain.com  # Only used for dev
 DJANGO_SUPERUSER_PASSWORD=CHANGEME         # Only used for dev
 CLIENT_MAX_BODY_SIZE=5G    # Max filesize allowed by Nginx
+TIMEZONE=UTC
 SQL_ENGINE=django.db.backends.postgresql
 SQL_DATABASE=CHANGEME
 SQL_USER=CHANGEME

--- a/shifter/shifter/settings.py
+++ b/shifter/shifter/settings.py
@@ -161,7 +161,7 @@ LOGGING = {
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = os.environ.get("TIMEZONE", "UTC")
 
 USE_I18N = True
 

--- a/shifter/shifter/settings.py
+++ b/shifter/shifter/settings.py
@@ -61,6 +61,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'shifter_auth.middleware.ensure_password_changed',
+    'shifter_auth.middleware.activate_timezone',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/shifter/shifter_auth/middleware.py
+++ b/shifter/shifter_auth/middleware.py
@@ -1,5 +1,8 @@
+import zoneinfo
+
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils import timezone
 
 
 def ensure_password_changed(get_response):
@@ -17,5 +20,21 @@ def ensure_password_changed(get_response):
 
         response = get_response(request)
         return response
+
+    return middleware
+
+
+def activate_timezone(get_response):
+    def middleware(request):
+        try:
+            tzname = request.COOKIES.get("django_timezone")
+            if tzname:
+                timezone.activate(zoneinfo.ZoneInfo(tzname))
+            else:
+                timezone.deactivate()
+        except Exception:
+            timezone.deactivate()
+
+        return get_response(request)
 
     return middleware

--- a/shifter/shifter_auth/middleware.py
+++ b/shifter/shifter_auth/middleware.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 
 def ensure_password_changed(get_response):
-    CHANGE_PASSWORD_URL = "shifter_auth:change-password"
+    CHANGE_PASSWORD_URL = "shifter_auth:settings"
 
     ALLOW_LIST = [
         reverse("shifter_auth:logout")

--- a/shifter/shifter_auth/templates/shifter_auth/settings.html
+++ b/shifter/shifter_auth/templates/shifter_auth/settings.html
@@ -1,13 +1,14 @@
 {% extends 'base.html' %}
 
-{% block title %}<title>Change Your Password | Shifter</title>{% endblock %}
+{% block title %}<title>Settings | Shifter</title>{% endblock %}
 
 {% block content %}
 <div class="standard-page-width">
     <div class="py-2">
-        <h1 class="title">Change Your Password</h1>
+        <h1 class="title">Settings</h1>
     </div>
     <div class="p-2">
+        <h2 class="text-2xl font-medium">Change Password</h2>
         <p class="border-b-2 border-gray-400 pb-2">After changing your password, you will automatically be logged out and must login with your new password.</p>
         {% if user.change_password_on_login %}<div class="my-4 rounded text-center font-semibold border border-blue-600 bg-blue-300">You need to reset your password before you can continue.</div>{% endif %}
         <form class="space-y-1 p2" method="post">

--- a/shifter/shifter_auth/tests.py
+++ b/shifter/shifter_auth/tests.py
@@ -49,7 +49,7 @@ class EnsurePasswordResetMiddlewareTest(TestCase):
         client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
         response = client.get(reverse("shifter_files:index"))
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse("shifter_auth:change-password"))
+        self.assertEqual(response.url, reverse("shifter_auth:settings"))
 
     def test_allow_logout(self):
         client = Client()
@@ -62,7 +62,7 @@ class EnsurePasswordResetMiddlewareTest(TestCase):
     def test_allow_password_reset(self):
         client = Client()
         client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
-        response = client.get(reverse("shifter_auth:change-password"))
+        response = client.get(reverse("shifter_auth:settings"))
         self.assertEqual(response.status_code, 200)
 
 
@@ -75,13 +75,13 @@ class ChangePasswordViewTest(TestCase):
     def test_page_load(self):
         client = Client()
         client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
-        response = client.get(reverse("shifter_auth:change-password"))
+        response = client.get(reverse("shifter_auth:settings"))
         self.assertEqual(response.status_code, 200)
 
     def test_successful_form_submit(self):
         client = Client()
         client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
-        response = client.post(reverse("shifter_auth:change-password"), {
+        response = client.post(reverse("shifter_auth:settings"), {
             "new_password": TEST_USER_NEW_PASSWORD,
             "confirm_password": TEST_USER_NEW_PASSWORD
         })
@@ -99,7 +99,7 @@ class ChangePasswordViewTest(TestCase):
     def test_unsuccessful_form_submit(self):
         client = Client()
         client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
-        response = client.post(reverse("shifter_auth:change-password"), {
+        response = client.post(reverse("shifter_auth:settings"), {
             "new_password": TEST_USER_NEW_PASSWORD,
             "confirm_password": TEST_USER_NEW_PASSWORD + "wrong"
         })

--- a/shifter/shifter_auth/urls.py
+++ b/shifter/shifter_auth/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from django.contrib.auth.views import LoginView
-from .views import logoutView, ChangePasswordView, CreateNewUserView
+from .views import logoutView, SettingsView, CreateNewUserView
 
 app_name = "shifter_auth"
 urlpatterns = [
@@ -9,8 +9,8 @@ urlpatterns = [
                            redirect_authenticated_user=True),
          name="login"),
     path('logout', logoutView, name="logout"),
-    path('change-password', ChangePasswordView.as_view(),
-         name="change-password"),
+    path('setings', SettingsView.as_view(),
+         name="settings"),
     path('new-user',
          CreateNewUserView.as_view(),
          name="create-new-user")

--- a/shifter/shifter_auth/views.py
+++ b/shifter/shifter_auth/views.py
@@ -18,8 +18,8 @@ def logoutView(request):
     return redirect("shifter_files:index")
 
 
-class ChangePasswordView(LoginRequiredMixin, FormView):
-    template_name = "shifter_auth/change_password.html"
+class SettingsView(LoginRequiredMixin, FormView):
+    template_name = "shifter_auth/settings.html"
     form_class = ChangePasswordForm
     success_url = reverse_lazy("shifter_files:index")
 

--- a/shifter/shifter_files/templates/shifter_files/file_download_landing.html
+++ b/shifter/shifter_files/templates/shifter_files/file_download_landing.html
@@ -14,9 +14,9 @@
     </div>
     <div class="py-2">
         <div class="flex flex-wrap justify-center md:justify-between pt-8">
-            <div><span class="font-semibold">Uploaded At:</span> {{ object.upload_datetime }}</div>
+            <div><span class="font-semibold">Uploaded At:</span> {{ object.upload_datetime|date:"M j, Y, g:i A" }}</div>
             <div><span class="font-semibold">File Size:</span> {{ object.file_content.size | pretty_file_size }}</div>
-            <div><span class="font-semibold">Expires At:</span> {{ object.expiry_datetime }}</div>
+            <div><span class="font-semibold">Expires At:</span> {{ object.expiry_datetime|date:"M j, Y, g:i A" }}</div>
         </div>
     </div>
 </div>

--- a/shifter/shifter_files/templates/shifter_files/fileupload_detail.html
+++ b/shifter/shifter_files/templates/shifter_files/fileupload_detail.html
@@ -16,10 +16,10 @@
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" /></svg>
             </button></div>
         <div class="flex flex-wrap justify-center md:justify-between pt-8">
-            <div><span class="font-semibold">Uploaded At:</span> {{ object.upload_datetime }}</div>
+            <div><span class="font-semibold">Uploaded At:</span> {{ object.upload_datetime|date:"M j, Y, g:i A" }}</div>
             <div><span class="font-semibold">File Size:</span> {{ object.file_content.size | pretty_file_size }}</div>
             <div>
-                <span class="font-semibold">Expires At:</span> {{ object.expiry_datetime }}
+                <span class="font-semibold">Expires At:</span> {{ object.expiry_datetime|date:"M j, Y, g:i A" }}
                 <button class="block w-full text-white bg-red-500 shadow-sm hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 font-medium rounded-lg text-sm px-5 py-2.5 text-center" type="button" data-modal-toggle="delete-file-modal">Delete File</button>
             </div>
         </div>

--- a/shifter/shifter_files/templates/shifter_files/fileupload_list.html
+++ b/shifter/shifter_files/templates/shifter_files/fileupload_list.html
@@ -20,8 +20,8 @@
                 {% for file in object_list %}
                 <tr class="hover:bg-slate-200 cursor-pointer" onclick="window.location='{% url 'shifter_files:file-details' file_hex=file.file_hex %}';">
                     <td class="py-3">{{ file.filename }}</td>
-                    <td class="py-3 hidden md:table-cell">{{ file.upload_datetime }}</td>
-                    <td class="py-3 hidden md:table-cell">{{ file.expiry_datetime }}</td>
+                    <td class="py-3 hidden md:table-cell">{{ file.upload_datetime|date:"M j, Y, g:i A" }}</td>
+                    <td class="py-3 hidden md:table-cell">{{ file.expiry_datetime|date:"M j, Y, g:i A" }}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/shifter/theme/templates/base.html
+++ b/shifter/theme/templates/base.html
@@ -34,7 +34,7 @@
                                         <a href="{% url 'shifter_files:myfiles' %}" class="block py-2 px-4 hover:bg-gray-100">My Files</a>
                                     </li>
                                     <li>
-                                        <a href="{% url 'shifter_auth:change-password' %}" class="block py-2 px-4 hover:bg-gray-100">Change Password</a>
+                                        <a href="{% url 'shifter_auth:settings' %}" class="block py-2 px-4 hover:bg-gray-100">Settings</a>
                                     </li>
                                     {% if user.is_staff %}
                                     <li>

--- a/shifter/theme/templates/base.html
+++ b/shifter/theme/templates/base.html
@@ -71,5 +71,10 @@
             </div>
         </div>
         <script src="{% static 'js/flowbite/flowbite.js' %}"></script>
+        <script>
+            // Timezone settings
+            const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone; // e.g. "America/New_York"
+            document.cookie = "django_timezone=" + timezone;
+        </script>
     </body>
 </html>


### PR DESCRIPTION
Closes #114
Closes #27 

Rather than letting the user set their timezone, we set it via cookie on request. This will work unless the user has disabled Javascript, or on their first visit to the website. I decided this was ok as allowing the user to set their timezone in the settings would still not work for anonymous users. In the future, we could update the times in Javascript to ensure it is always set correctly.

Also added ability to change the default timezone using an environment variable. This is the fallback value for anonymous users so it is nice for the user to set.