### PR TITLE
Docs #136:  Ppdate docs and docker files to point to ghcr

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ This project is still in development and may not be suitable to use in productio
 
 Before you begin, make sure you have installed Docker and Docker Compose on your system. If you're not sure how to do this, refer to the [Docker documentation](https://docs.docker.com/get-docker/) for instructions.
 
+By default, the `docker-compose.yml` will use the latest image from GHCR. However it still requires some config files from this repository, and the relative paths are important. This will be improved in the future.
+
 1. Download or clone this repository.
 2. Make a copy of the `.env EXAMPLE` file and name it `.env`. In your new copy, make sure DEBUG is set to 0, and change any values that are set to `CHANGEME` to the appropriate values for your deployment.
 3. In the .env file, update the DJANGO_ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS values to match your deployment.
-4. Build and start the development containers using the following command:
+4. Start the containers using the following command:
 ```
-docker-compose -f docker/docker-compose.yml up --build
+docker-compose -f docker/docker-compose.yml up
 ```
 5. To create an admin user, run the following command and follow the prompts:
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,8 +44,6 @@ COPY --from=builder /app/wheels /wheels
 COPY --from=builder /app/requirements.txt .
 RUN pip install --no-cache /wheels/*
 
-COPY ./shifter/entrypoint.sh $APP_HOME
-
 # copy project
 COPY ./shifter/ $APP_HOME
 
@@ -56,3 +54,6 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # chown all the files to the app user
 RUN chown -R app:app $APP_HOME
+
+ENTRYPOINT [ "/home/app/web/entrypoint.sh" ]
+CMD [ "gunicorn", "shifter.wsgi:application", "--bind", "0.0.0.0:8000", "--timeout", "600" ]

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -13,9 +13,11 @@ services:
     environment:
       - DJANGO_LOG_LEVEL=OFF
   nginx:
-    build: ../nginx
+    image: nginx:1.19.0-alpine
     restart: always
     command: nginx -t
+    volumes:
+      - ../nginx/nginx.conf:/etc/nginx/templates/default.conf.template
     depends_on:
       - web
     env_file:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,11 +29,11 @@ services:
     env_file:
       - ../.env
   nginx:
-    build: ../nginx
-    restart: always
+    image: nginx:1.19.0-alpine
     volumes:
       - static:/home/app/web/static
       - media:/home/app/web/media
+      - ../nginx/nginx.conf:/etc/nginx/templates/default.conf.template
     ports:
       - 1337:80
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,9 +16,7 @@ services:
   #   env_file:
   #     - ./.env
   web:
-    build:
-      context: ../
-      dockerfile: docker/Dockerfile
+    image: ghcr.io/tobysuch/shifter:0.2.0
     restart: always
     volumes:
       - static:/home/app/web/static

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,8 +19,6 @@ services:
     build:
       context: ../
       dockerfile: docker/Dockerfile
-    entrypoint: /home/app/web/entrypoint.sh
-    command: gunicorn shifter.wsgi:application --bind 0.0.0.0:8000 --timeout 600
     restart: always
     volumes:
       - static:/home/app/web/static

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,0 @@
-FROM nginx:1.19.0-alpine
-
-RUN rm /etc/nginx/conf.d/default.conf
-COPY nginx.conf /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
Change prod docker-compose file to use prebuilt images (Dockerhub nginx and GHCR Shifter)
Updated documentation to reflect that

The relative paths are currently required though which makes things a little trickier. #137 will help with this though.

Closes #136 