### PR TITLE
Install requirements_dev during build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,8 @@ ENV PYTHONUNBUFFERED 1
 RUN apk add --update postgresql-dev gcc python3-dev musl-dev
 
 RUN pip install --upgrade pip
-RUN pip install ruff
+COPY ./shifter/requirements_dev.txt .
+RUN pip install -r requirements_dev.txt
 COPY ./shifter/requirements.txt .
 RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
 


### PR DESCRIPTION
Rather than hardcoding lint versions, use what is saved in requirements_dev.txt which is managed by dependabot.