### PR TITLE
#219 Add debug info in site settings page

### DIFF
--- a/docker/dev/Dockerfile.dev
+++ b/docker/dev/Dockerfile.dev
@@ -10,6 +10,7 @@ COPY ./shifter/ .
 
 RUN chmod +x ./entrypoint.sh
 
+ENV APP_VERSION="DEV"
 EXPOSE 8000
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker/dev/docker-compose.test.yml
+++ b/docker/dev/docker-compose.test.yml
@@ -6,7 +6,7 @@ services:
       context: ../../
       dockerfile: docker/Dockerfile
     entrypoint: /home/app/web/entrypoint.sh
-    command: python manage.py test
+    command: python manage.py test --parallel
     restart: always
     env_file:
       - "../../.env EXAMPLE"

--- a/docker/dev/docker-compose.test.yml
+++ b/docker/dev/docker-compose.test.yml
@@ -1,5 +1,5 @@
 name: shifter-test
-   
+
 services:
   web:
     build:
@@ -13,6 +13,7 @@ services:
     environment:
       - DJANGO_LOG_LEVEL=OFF
       - TEST_MODE=1
+      - APP_VERSION=TESTING
   nginx:
     image: nginx:1.19.0-alpine
     restart: always

--- a/shifter/entrypoint.sh
+++ b/shifter/entrypoint.sh
@@ -46,7 +46,7 @@ else
         python manage.py crontab add
         crond -b
     else
-        echo "In testing mode - not setting up con."
+        echo "In testing mode - not setting up cron."
     fi
     python manage.py collectstatic --no-input --clear > /dev/null
 fi

--- a/shifter/shifter/settings.py
+++ b/shifter/shifter/settings.py
@@ -16,6 +16,7 @@ from datetime import timedelta
 from pathlib import Path
 
 from django import forms
+from django.utils import timezone
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -262,3 +263,9 @@ CRONJOBS = [
         "shifter_files.cron.delete_expired_files",
     )
 ]
+
+# Environment information
+SHIFTER_VERSION = os.environ.get("APP_VERSION", "Unknown")
+PYTHON_VERSION = os.environ.get("PYTHON_VERSION", "Unknown")
+DB_OPTION = db_option.upper()
+STARTUP_TIME = timezone.now()

--- a/shifter/shifter_files/models.py
+++ b/shifter/shifter_files/models.py
@@ -38,6 +38,10 @@ class FileUpload(models.Model):
         return cls.objects.filter(expiry_datetime__lte=Now())
 
     @classmethod
+    def get_non_expired_files(cls):
+        return cls.objects.filter(expiry_datetime__gt=Now())
+
+    @classmethod
     def delete_expired_files(cls):
         files = cls.get_expired_files()
         num_files = files.count()

--- a/shifter/shifter_files/tests/test_commands.py
+++ b/shifter/shifter_files/tests/test_commands.py
@@ -1,4 +1,5 @@
 import datetime
+import tempfile
 from io import StringIO
 from shutil import rmtree
 
@@ -6,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from shifter_files.models import FileUpload
@@ -18,6 +19,7 @@ TEST_FILE_NAME = "mytestfile.txt"
 TEST_FILE_CONTENT = b"Hello, World!"
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class CleanUpExpiredCommandTest(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/shifter/shifter_files/tests/test_cron.py
+++ b/shifter/shifter_files/tests/test_cron.py
@@ -1,11 +1,12 @@
 import datetime
 import pathlib
+import tempfile
 from shutil import rmtree
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from shifter_files.cron import delete_expired_files
@@ -18,6 +19,7 @@ TEST_FILE_NAME = "mytestfile.txt"
 TEST_FILE_CONTENT = b"Hello, World!"
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class DeleteExpiredFilesTest(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/shifter/shifter_files/tests/test_models.py
+++ b/shifter/shifter_files/tests/test_models.py
@@ -1,11 +1,12 @@
 import datetime
 import pathlib
+import tempfile
 from shutil import rmtree
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from shifter_files.models import FileUpload
@@ -17,6 +18,7 @@ TEST_FILE_NAME = "mytestfile.txt"
 TEST_FILE_CONTENT = b"Hello, World!"
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class FileUploadModelTest(TestCase):
     def setUp(self):
         User = get_user_model()
@@ -54,7 +56,7 @@ class FileUploadModelTest(TestCase):
             delta=datetime.timedelta(minutes=1),
         )
         # Ensure file has been uploaded to the correct location
-        path = pathlib.Path("media/uploads/" + TEST_FILE_NAME)
+        path = pathlib.Path(settings.MEDIA_ROOT + "/uploads/" + TEST_FILE_NAME)
         self.assertTrue(path.is_file())
 
     def test_is_expired_false(self):

--- a/shifter/shifter_files/tests/views/test_file_delete_view.py
+++ b/shifter/shifter_files/tests/views/test_file_delete_view.py
@@ -1,10 +1,11 @@
 import datetime
+import tempfile
 from shutil import rmtree
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -20,6 +21,7 @@ TEST_FILE_NAME = "mytestfile.txt"
 TEST_FILE_CONTENT = b"Hello, World!"
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class FileDeleteViewTest(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/shifter/shifter_files/tests/views/test_file_details_view.py
+++ b/shifter/shifter_files/tests/views/test_file_details_view.py
@@ -1,10 +1,11 @@
 import datetime
+import tempfile
 from shutil import rmtree
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -21,6 +22,7 @@ TEST_FILE_NAME = "mytestfile.txt"
 TEST_FILE_CONTENT = b"Hello, World!"
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class FileDetailsViewTest(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/shifter/shifter_files/tests/views/test_file_download_landing_view.py
+++ b/shifter/shifter_files/tests/views/test_file_download_landing_view.py
@@ -1,10 +1,11 @@
 import datetime
+import tempfile
 from shutil import rmtree
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -20,6 +21,7 @@ TEST_FILE_NAME = "mytestfile.txt"
 TEST_FILE_CONTENT = b"Hello, World!"
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class FileDownloadLandingViewTest(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/shifter/shifter_files/tests/views/test_file_download_view.py
+++ b/shifter/shifter_files/tests/views/test_file_download_view.py
@@ -1,10 +1,11 @@
 import datetime
+import tempfile
 from shutil import rmtree
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -20,6 +21,7 @@ TEST_FILE_NAME = "mytestfile.txt"
 TEST_FILE_CONTENT = b"Hello, World!"
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class FileDownloadViewTest(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/shifter/shifter_files/tests/views/test_index_view.py
+++ b/shifter/shifter_files/tests/views/test_index_view.py
@@ -47,7 +47,7 @@ class IndexViewTest(TestCase):
         client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
         response = client.get(reverse("shifter_files:index"))
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('<h1 class="title">Upload File</h1>')
+        self.assertTemplateUsed(response, "shifter_files/file_upload.html")
 
     def test_file_upload(self):
         client = Client()

--- a/shifter/shifter_files/tests/views/test_index_view.py
+++ b/shifter/shifter_files/tests/views/test_index_view.py
@@ -1,12 +1,13 @@
 import datetime
 import json
 import pathlib
+import tempfile
 from shutil import rmtree
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -23,6 +24,7 @@ TEST_FILE_NAME = "mytestfile.txt"
 TEST_FILE_CONTENT = b"Hello, World!"
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class IndexViewTest(TestCase):
     def setUp(self):
         User = get_user_model()
@@ -82,7 +84,11 @@ class IndexViewTest(TestCase):
         )
         # Ensure file has been uploaded to the correct location
         path = pathlib.Path(
-            "media/uploads/" + TEST_FILE_NAME + "_" + file_upload.file_hex
+            settings.MEDIA_ROOT
+            + "/uploads/"
+            + TEST_FILE_NAME
+            + "_"
+            + file_upload.file_hex
         )
         self.assertTrue(path.is_file())
 

--- a/shifter/shifter_site_settings/templates/shifter_site_settings/site_settings.html
+++ b/shifter/shifter_site_settings/templates/shifter_site_settings/site_settings.html
@@ -63,6 +63,45 @@
             </div>
         </form>
     </div>
+    <div>
+        <h2 class="text-gray-800 text-2xl font-medium border-t-2 border-gray-400 py-4">Site Information</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-2">
+            <div class="flex flex-col justify-between rounded-lg p-2 border-2 border-sky-200 bg-sky-100 w-full text-center space-y-2">
+                <p class="font-semibold">Debug Mode</p>
+                <p class="font-black text-4xl {% if debug_mode %}text-red-600{% else %}text-primary{% endif %}">{{ debug_mode }}</p>
+            </div>
+            <div class="flex flex-col justify-between rounded-lg p-2 border-2 border-sky-200 bg-sky-100 w-full text-center space-y-2">
+                <p class="font-semibold">Shifter Version</p>
+                <p class="font-black text-4xl text-primary">{{ shifter_version }}</p>
+            </div>
+            <div class="flex flex-col justify-between rounded-lg p-2 border-2 border-sky-200 bg-sky-100 w-full text-center space-y-2">
+                <p class="font-semibold">Python Version</p>
+                <p class="font-black text-4xl text-primary">{{ python_version }}</p>
+            </div>
+            <div class="flex flex-col justify-between rounded-lg p-2 border-2 border-sky-200 bg-sky-100 w-full text-center space-y-2">
+                <p class="font-semibold">DB Engine</p>
+                <p class="font-black text-4xl text-primary">{{ db_engine }}</p>
+            </div>
+            <div class="relative flex flex-col justify-between rounded-lg p-2 border-2 border-sky-200 bg-sky-100 w-full text-center space-y-2" data-tooltip-target="tooltip-uptime">
+                <span class="absolute top-0 right-0 mt-1 mr-1 w-2 h-2 bg-primary rounded-full"></span>
+                <p class="font-semibold">Uptime</p>
+                <p class="font-black text-4xl text-primary">{{ uptime }}</p>
+            </div>
+            <div class="relative flex flex-col justify-between rounded-lg p-2 border-2 border-sky-200 bg-sky-100 w-full text-center space-y-2" data-tooltip-target="tooltip-expired-files">
+                <span class="absolute top-0 right-0 mt-1 mr-1 w-2 h-2 bg-primary rounded-full"></span>
+                <p class="font-semibold">Active Files</p>
+                <p class="font-black text-4xl text-primary">{{ num_active_files }}</p>
+            </div>
+        </div>
+        <div id="tooltip-uptime" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-primary rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700">
+            Started at: {{ startup_time }}
+            <div class="tooltip-arrow" data-popper-arrow></div>
+        </div>
+        <div id="tooltip-expired-files" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-primary rounded-lg shadow-sm opacity-0 tooltip dark:bg-gray-700">
+            {{ num_expired_files }} file(s) to be cleaned up.
+            <div class="tooltip-arrow" data-popper-arrow></div>
+        </div>
+    </div>
 </div>
 <script>
     document.getElementById('cleanup-expired-files-btn').addEventListener('click', Shifter.cleanupExpiredFiles);

--- a/shifter/shifter_site_settings/views.py
+++ b/shifter/shifter_site_settings/views.py
@@ -1,6 +1,10 @@
+from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.urls import reverse_lazy
+from django.utils import timesince
 from django.views.generic import FormView
+
+from shifter_files.models import FileUpload
 
 from .forms import SiteSettingsForm
 from .models import SiteSetting
@@ -25,3 +29,21 @@ class SiteSettingsView(UserPassesTestMixin, FormView):
         context = self.get_context_data()
         context["message"] = "Settings Saved!"
         return self.render_to_response(context)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context["debug_mode"] = bool(settings.DEBUG)
+        context["shifter_version"] = settings.SHIFTER_VERSION
+        context["python_version"] = settings.PYTHON_VERSION
+        context["db_engine"] = settings.DB_OPTION.upper()
+        context["uptime"] = timesince.timesince(settings.STARTUP_TIME, depth=1)
+        context["startup_time"] = settings.STARTUP_TIME.strftime(
+            "%Y-%m-%d %H:%M:%S %Z"
+        )
+        context["num_active_files"] = (
+            FileUpload.get_non_expired_files().count()
+        )
+        context["num_expired_files"] = FileUpload.get_expired_files().count()
+
+        return context


### PR DESCRIPTION
Adds several debug info items to the site settings page. 

Items include:
- Debug Mode
- Shifter Version
- Python Version
- DB Engine
- App up time
- Number of active files.

Also some test tweaks, fixing broken tests and parallelised the test running to speed them up.