### PR TITLE
#400 Show copy download button properly on small screens

### DIFF
--- a/shifter/shifter_files/templates/shifter_files/fileupload_detail.html
+++ b/shifter/shifter_files/templates/shifter_files/fileupload_detail.html
@@ -54,7 +54,7 @@
 
     <div id="notification" class="fixed bottom-4 inset-x-0 flex justify-center transition-opacity duration-500 opacity-0 hidden">
         <span class="bg-primary text-white p-4 rounded-lg shadow-lg">
-            Copied link to clipboard.
+            Download link copied to clipboard.
         </span>
     </div>
 </div>

--- a/shifter/shifter_files/templates/shifter_files/fileupload_detail.html
+++ b/shifter/shifter_files/templates/shifter_files/fileupload_detail.html
@@ -51,19 +51,35 @@
             </div>
         </div>
     </div>
+
+    <div id="notification" class="fixed bottom-4 inset-x-0 flex justify-center transition-opacity duration-500 opacity-0 hidden">
+        <span class="bg-primary text-white p-4 rounded-lg shadow-lg">
+            Copied link to clipboard.
+        </span>
+    </div>
 </div>
 
-<!-- Select text on click -->
 <script>
     function copyToClipboard(text) {
         navigator.clipboard.writeText(text).then(
-            function() {
+            () => {
                 console.log('Copied link to clipboard');
+                var notification = document.getElementById('notification');
+                notification.classList.remove('hidden');
+                setTimeout(() => {
+                    notification.classList.remove('opacity-0');
+                }, 10);
+                setTimeout(() => {
+                    notification.classList.add('opacity-0');
+                    setTimeout(() => {
+                        notification.classList.add('hidden');
+                    }, 500);
+                }, 3000);
             },
-            function(err) {
+            (err) => {
                 console.error('Could not copy link to clipboard: ', err);
             }
         );
-    };
+    }
 </script>
 {% endblock %}

--- a/shifter/shifter_files/templates/shifter_files/fileupload_detail.html
+++ b/shifter/shifter_files/templates/shifter_files/fileupload_detail.html
@@ -10,17 +10,19 @@
         <h1 class="title">{{ object.filename }}</h1>
     </div>
     <div class="py-2">
-        <div id="download-link" class="input-primary flex justify-center items-center text-center">
-            <a href="{{ full_download_url }}" class="underline">{{ full_download_url }}</a>
-            <button class="border bg-white p-1 ml-2 rounded-md active:bg-gray-200" onclick="copyToClipboard('{{ full_download_url }}')">
+        <div id="download-link" class="flex items-center w-auto flex-grow">
+            <span class="rounded-l-lg p-2 border-2 bg-sky-100 border-sky-200 flex-grow text-center truncate">
+                <a href="{{ full_download_url }}" class="underline">{{ full_download_url }}</a>
+            </span>
+            <button class="rounded-r-lg p-2 border-y-2 border-r-2 bg-gray-100 border-gray-200 hover:bg-gray-200" onclick="copyToClipboard('{{ full_download_url }}')">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" /></svg>
             </button></div>
-        <div class="flex flex-wrap justify-center md:justify-between pt-8">
+        <div class="flex flex-col text-center justify-between pt-8 gap-2 lg:flex-row">
             <div><span class="font-semibold">Uploaded At:</span> <span class="localized-time" data-iso-time="{{ object.upload_datetime|date:"c" }}">{{ object.upload_datetime|date:"M j, Y, g:i A T" }}</span></div>
             <div><span class="font-semibold">File Size:</span> {{ object.file_content.size | pretty_file_size }}</div>
-            <div>
-                <span class="font-semibold">Expires At:</span> <span class="localized-time" data-iso-time="{{ object.expiry_datetime|date:"c" }}">{{ object.expiry_datetime|date:"M j, Y, g:i A T" }}</span>
-                <button class="block w-full text-white bg-red-500 shadow-sm hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 font-medium rounded-lg text-sm px-5 py-2.5 text-center" type="button" data-modal-target="delete-file-modal" data-modal-toggle="delete-file-modal">Delete File</button>
+            <div class="flex flex-col align-center">
+                <span class="mb-2"><span class="font-semibold">Expires At:</span> <span class="localized-time" data-iso-time="{{ object.expiry_datetime|date:"c" }}">{{ object.expiry_datetime|date:"M j, Y, g:i A T" }}</span></span>
+                <span><button class="w-fit lg:w-full text-white bg-red-500 shadow-sm hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 font-medium rounded-lg text-sm px-5 py-2.5 text-center" type="button" data-modal-target="delete-file-modal" data-modal-toggle="delete-file-modal">Delete File</button></span>
             </div>
         </div>
     </div>

--- a/shifter/templates/base.html
+++ b/shifter/templates/base.html
@@ -8,7 +8,7 @@
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link rel="icon" href="{% static 'img/favicon.ico' %}" sizes="32x32">
         <link rel="icon" href="{% static 'img/logo.svg' %}" type="image/svg+xml">
-        <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
+        <link rel="apple-touch-icon" href="{% static 'img/apple-touch-icon.png' %}">
         <script src="{% static 'js/timezoneutils-bundle.js' %}"></script>
         {% block head %}
         {% endblock %}


### PR DESCRIPTION
Truncated download link and restyled copy to clipboard button to fit properly on small screens. 

Also added a message to inform user that the link has been copied to clipboard

Some other minor changes including changing styling for info text (especially expires timestamp and delete button) and fix for the apple touch icon URL.

Closes #400 