### PR TITLE
#427 Fix error on index page when setting max expiry setting too high

### DIFF
--- a/shifter/assets/js/timezone-utils.js
+++ b/shifter/assets/js/timezone-utils.js
@@ -36,8 +36,10 @@ function convertDateTimeLocalFormElementToLocalTime(input) {
   const minVal = new Date(input.getAttribute("data-min-iso"));
   input.min = convertDateToFormFieldFormat(minVal);
 
-  const maxVal = new Date(input.getAttribute("data-max-iso"));
-  input.max = convertDateToFormFieldFormat(maxVal);
+  if (input.getAttribute("data-max-iso") != null) {
+    const maxVal = new Date(input.getAttribute("data-max-iso"));
+    input.max = convertDateToFormFieldFormat(maxVal);
+  }
 }
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/shifter/shifter/settings.py
+++ b/shifter/shifter/settings.py
@@ -262,11 +262,15 @@ SITE_SETTINGS = {
         "default": 24 * 14,  # 2 weeks
         "label": "Default Expiry Offset (hours)",
         "field_type": forms.IntegerField,
+        "min_value": 0,
+        "max_value": 2147483647,
     },
     "max_expiry_offset": {
         "default": 24 * 365 * 5,  # 5 years
         "label": "Maximum Expiry Offset (hours)",
         "field_type": forms.IntegerField,
+        "min_value": 0,
+        "max_value": 2147483647,
     },
 }
 

--- a/shifter/shifter_files/forms.py
+++ b/shifter/shifter_files/forms.py
@@ -30,35 +30,48 @@ class FileUploadForm(forms.ModelForm):
         )
         exp_date_str = exp_date.strftime(settings.DATETIME_INPUT_FORMATS[0])
         self.fields["expiry_datetime"].initial = exp_date_str
+        self.fields["expiry_datetime"].widget.attrs["data-initial-iso"] = (
+            exp_date.isoformat()
+        )
+
         exp_date_min = timezone.now()
         exp_date_min_str = exp_date_min.strftime(
             settings.DATETIME_INPUT_FORMATS[0]
         )
         self.fields["expiry_datetime"].widget.attrs["min"] = exp_date_min_str
-        exp_date_max = timezone.now() + timedelta(
-            hours=int(SiteSetting.get_setting("max_expiry_offset"))
-        )
-        exp_date_max_str = exp_date_max.strftime(
-            settings.DATETIME_INPUT_FORMATS[0]
-        )
-        self.fields["expiry_datetime"].widget.attrs["max"] = exp_date_max_str
-        self.fields["expiry_datetime"].widget.attrs["data-initial-iso"] = (
-            exp_date.isoformat()
-        )
         self.fields["expiry_datetime"].widget.attrs["data-min-iso"] = (
             exp_date_min.isoformat()
         )
-        self.fields["expiry_datetime"].widget.attrs["data-max-iso"] = (
-            exp_date_max.isoformat()
-        )
+
+        try:
+            exp_date_max = timezone.now() + timedelta(
+                hours=int(SiteSetting.get_setting("max_expiry_offset"))
+            )
+            exp_date_max_str = exp_date_max.strftime(
+                settings.DATETIME_INPUT_FORMATS[0]
+            )
+            self.fields["expiry_datetime"].widget.attrs["max"] = (
+                exp_date_max_str
+            )
+            self.fields["expiry_datetime"].widget.attrs["data-max-iso"] = (
+                exp_date_max.isoformat()
+            )
+        except OverflowError:
+            # If the max expiry offset is too large, don't set a max expiry
+            # It is too far in the future to matter.
+            pass
 
     def clean_expiry_datetime(self):
         expiry_datetime = self.cleaned_data["expiry_datetime"]
         current_datetime = timezone.now()
         max_expiry_offset = SiteSetting.get_setting("max_expiry_offset")
-        max_expiry_time = current_datetime + timedelta(
-            hours=int(max_expiry_offset)
-        )
+        dont_validate_max_expiry = False
+        try:
+            max_expiry_time = current_datetime + timedelta(
+                hours=int(max_expiry_offset)
+            )
+        except OverflowError:
+            dont_validate_max_expiry = True
 
         if expiry_datetime < current_datetime:
             raise ValidationError(
@@ -66,7 +79,7 @@ class FileUploadForm(forms.ModelForm):
                 code="expiry-time-past",
             )
 
-        if expiry_datetime > max_expiry_time:
+        if not dont_validate_max_expiry and expiry_datetime > max_expiry_time:
             raise ValidationError(
                 "You can't upload a file with an expiry time more than "
                 f"{max_expiry_offset} hours in the future.",

--- a/shifter/shifter_site_settings/forms.py
+++ b/shifter/shifter_site_settings/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.conf import settings
+from django.core.validators import MaxValueValidator, MinValueValidator
 
 from .models import SiteSetting
 
@@ -19,3 +20,17 @@ class SiteSettingsForm(forms.Form):
                 self.fields[
                     f"setting_{setting.name}"
                 ].help_text = setting_config["tooltip"]
+            if "min_value" in setting_config:
+                self.fields[f"setting_{setting.name}"].validators.append(
+                    MinValueValidator(
+                        setting_config["min_value"],
+                        "Minimum value: %(limit_value)s",
+                    )
+                )
+            if "max_value" in setting_config:
+                self.fields[f"setting_{setting.name}"].validators.append(
+                    MaxValueValidator(
+                        setting_config["max_value"],
+                        "Maximum value: %(limit_value)s",
+                    )
+                )


### PR DESCRIPTION
Fix error case when setting max expiry too high. 

This consisted of two parts
- Value being too big to convert to C int - I have put a hard limit on max expiry hours to prevent this
- Value being too big to convert to datetime. Python has a max datetime of 9999-12-31 23:59:59.999999. If the code detects that the max expiry date is larger than this, we now just skip the max expiry checks as it would be too far in the future to matter.

Thanks to @helpimnotdrowning for finding the bug!