### PR TITLE
fix: #590 Add db to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ shifter/media/
 shifter/static/css
 shifter/static/js
 .DS_Store
+shifter/db/*


### PR DESCRIPTION
A local db file used for testing can be included in the production build. This causes issues such as there already being an admin user created so preventing others from getting the proper first time setup experience.

Closes #590 and a new prod image needs to be made.