### PR TITLE
fix: resolve Alpine store race condition in FilePond initialization

### DIFF
--- a/shifter/assets/js/filepond.js
+++ b/shifter/assets/js/filepond.js
@@ -5,7 +5,7 @@ import "filepond/dist/filepond.min.css";
 
 FilePond.registerPlugin(FilePondPluginFileValidateSize);
 
-document.addEventListener("alpine:init", () => {
+function registerAlpineStores() {
   if (!window.Alpine) {
     return;
   }
@@ -38,7 +38,15 @@ document.addEventListener("alpine:init", () => {
   window.Alpine.store("uploadState", {
     showZipName: false,
   });
-});
+}
+
+// Register stores immediately if Alpine has already started
+if (window.Alpine && !window.Alpine.version.includes("loading")) {
+  registerAlpineStores();
+} else {
+  // Otherwise wait for alpine:init event
+  document.addEventListener("alpine:init", registerAlpineStores);
+}
 
 function getUploadAlertsStore() {
   if (!window.Alpine) {


### PR DESCRIPTION
## Summary
- Fixed race condition preventing Alpine.js stores from being registered
- FilePond now initializes correctly on the upload page
- Stores are registered immediately if Alpine has already started, otherwise waits for alpine:init event

## Problem
The file upload page was showing a basic file input instead of the FilePond drag-and-drop interface. Console errors showed that `$store.uploadAlerts` and `$store.uploadState` were undefined.

This occurred because `shifter.js` and `filepond.js` are separate ES module bundles that load asynchronously. When `shifter.js` completed first, it called `Alpine.start()` before `filepond.js` could set up its `alpine:init` event listener, causing the stores to never be registered.

## Solution
Modified `filepond.js` to check if Alpine has already started when the module loads:
- If Alpine is ready, registers stores immediately
- Otherwise, waits for the `alpine:init` event as before

This handles both loading orders correctly.

## Test plan
- [ ] Rebuild frontend assets with `npm run build`
- [ ] Navigate to the file upload page
- [ ] Verify FilePond drag-and-drop interface appears
- [ ] Verify no console errors about undefined stores
- [ ] Test file upload functionality works correctly
- [ ] Test multi-file upload with ZIP creation
- [ ] Test expiry date validation and error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)