### PR TITLE
feat: add user management for admin users

### DIFF
--- a/shifter/shifter_auth/forms.py
+++ b/shifter/shifter_auth/forms.py
@@ -24,6 +24,8 @@ class ChangePasswordForm(forms.Form):
 
 
 class NewUserForm(forms.Form):
+    """Form for first-time setup with password fields."""
+
     email = forms.EmailField(label="Email")
     password = forms.CharField(widget=forms.PasswordInput, label="Password")
     confirm_password = forms.CharField(
@@ -51,3 +53,75 @@ class NewUserForm(forms.Form):
             raise forms.ValidationError("Email already taken!")
 
         return email
+
+
+class CreateUserForm(forms.Form):
+    """Form for creating new users with auto-generated passwords."""
+
+    email = forms.EmailField(label="Email")
+
+    def clean_email(self):
+        email = self.cleaned_data["email"]
+        User = get_user_model()
+        email_used = User.objects.filter(email=email).count() > 0
+
+        if email_used:
+            raise forms.ValidationError("Email already taken!")
+
+        return email
+
+
+class UserSearchForm(forms.Form):
+    """Form for searching users in the user list."""
+
+    search = forms.CharField(
+        required=False,
+        label="Search",
+        widget=forms.TextInput(
+            attrs={
+                "class": "input-primary flex-grow",
+                "placeholder": "Search users by email",
+            }
+        ),
+    )
+
+
+class UserEditForm(forms.ModelForm):
+    """Form for editing user details."""
+
+    class Meta:
+        model = get_user_model()
+        fields = ["email", "is_staff", "is_active"]
+        labels = {
+            "email": "Email",
+            "is_staff": "Administrator",
+            "is_active": "Active",
+        }
+
+    def __init__(self, *args, editing_self=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.editing_self = editing_self
+
+        # If editing self, disable is_staff and is_active fields
+        if editing_self:
+            self.fields["is_staff"].disabled = True
+            self.fields["is_active"].disabled = True
+
+    def clean_email(self):
+        email = self.cleaned_data["email"]
+        User = get_user_model()
+        # Check if email is taken by another user (not the current instance)
+        existing = User.objects.filter(email=email).exclude(
+            pk=self.instance.pk
+        )
+        if existing.exists():
+            raise forms.ValidationError("Email already taken!")
+        return email
+
+    def clean(self):
+        cleaned_data = super().clean()
+        # Double-check: if editing self, preserve original values
+        if self.editing_self:
+            cleaned_data["is_staff"] = self.instance.is_staff
+            cleaned_data["is_active"] = self.instance.is_active
+        return cleaned_data

--- a/shifter/shifter_auth/templates/shifter_auth/new_user.html
+++ b/shifter/shifter_auth/templates/shifter_auth/new_user.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
 
-{% block title %}<title>Register New User | Shifter</title>{% endblock %}
+{% block title %}<title>Create New User | Shifter</title>{% endblock %}
 
 {% block content %}
 <div class="standard-page-width">
     <div class="py-2">
-        <h1 class="title">Register New User</h1>
+        <h1 class="title">Create New User</h1>
     </div>
     <div>
-        <p class="text-gray-800 border-b-2 border-gray-400 pb-2">New users will be able to upload their own files to share. They will not be able to change site settings, or create new users.</p>
+        <p class="text-gray-800 border-b-2 border-gray-400 pb-2">New users will be able to upload their own files to share. They will not be able to change site settings, or create new users. A temporary password will be automatically generated.</p>
     </div>
     <div class="p-2">
         <form class="space-y-1 p2" method="post">
@@ -21,20 +21,8 @@
             </div>
             <input name="{{ form.email.html_name }}" class="w-full input-primary" placeholder="your@email.com">
 
-            <div class="flex">
-                <p class="text-gray-800">{{ form.password.label }}:</p>
-                {% if form.password.errors %}<div class="ml-2 error-box grow">{{ form.password.errors }}</div>{% endif %}
-            </div>
-            <input name="{{ form.password.html_name }}" type="password" class="w-full input-primary" placeholder="••••••••">
-
-            <div class="flex">
-                <p class="text-gray-800">{{ form.confirm_password.label }}:</p>
-                {% if form.confirm_password.errors %}<div class="ml-2 error-box grow">{{ form.confirm_password.errors }}</div>{% endif %}
-            </div>
-            <input name="{{ form.confirm_password.html_name }}" type="password" class="w-full input-primary" placeholder="••••••••">
-
             <div class="flex justify-end py-2">
-                <input type="submit" value="Register User" class="btn-primary">
+                <input type="submit" value="Create User" class="btn-primary">
             </div>
         </form>
     </div>

--- a/shifter/shifter_auth/templates/shifter_auth/user_create_success.html
+++ b/shifter/shifter_auth/templates/shifter_auth/user_create_success.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+
+{% block title %}<title>User Created | Shifter</title>{% endblock %}
+
+{% block content %}
+<div class="standard-page-width" x-data="{ showNotification: false, copyPassword() { navigator.clipboard.writeText('{{ new_password }}'); this.showNotification = true; setTimeout(() => { this.showNotification = false; }, 2000); } }">
+    <div class="py-2">
+        <h1 class="title">User Created</h1>
+    </div>
+    <div class="p-2">
+        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+            User account created for <strong>{{ user_email }}</strong>.
+        </div>
+        <p class="text-gray-800 mb-4">The temporary password is:</p>
+        <div class="flex items-center gap-2 mb-4">
+            <div class="bg-gray-100 p-4 rounded-lg text-center font-mono text-xl grow select-all">
+                {{ new_password }}
+            </div>
+            <button @click="copyPassword()" class="p-4 bg-gray-100 rounded-lg hover:bg-gray-200 cursor-pointer" title="Copy to clipboard">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+                </svg>
+            </button>
+        </div>
+        <p class="text-gray-600 mb-4">
+            Please share this password securely with the user. They will be required to change it upon their first login.
+        </p>
+        <div class="flex gap-2">
+            <a href="{% url 'shifter_auth:user-detail' pk=user_pk %}" class="btn-primary">View User</a>
+            <a href="{% url 'shifter_auth:user-list' %}" class="btn-primary">Back to User List</a>
+        </div>
+    </div>
+
+    <div x-show="showNotification" x-transition.opacity.duration.500ms class="fixed bottom-4 inset-x-0 flex justify-center" x-cloak>
+        <span class="bg-primary text-white p-4 rounded-lg">
+            Password copied to clipboard.
+        </span>
+    </div>
+</div>
+{% endblock %}

--- a/shifter/shifter_auth/templates/shifter_auth/user_detail.html
+++ b/shifter/shifter_auth/templates/shifter_auth/user_detail.html
@@ -1,0 +1,136 @@
+{% extends 'base.html' %}
+
+{% block title %}<title>Edit User: {{ object.email }} | Shifter</title>{% endblock %}
+
+{% block content %}
+<div class="standard-page-width">
+    <div class="py-2">
+        <h1 class="title">Edit User</h1>
+    </div>
+    <div>
+        <p class="text-gray-800 border-b-2 border-gray-400 pb-2">Edit user details, reset their password, or delete their account.</p>
+    </div>
+    <div class="p-2">
+        <form class="space-y-1 p2" method="post">
+            {% csrf_token %}
+            {% if form.non_field_errors %}<div class="error-box">{{ form.non_field_errors }}</div>{% endif %}
+
+            <div class="flex">
+                <p class="text-gray-800">{{ form.email.label }}:</p>
+                {% if form.email.errors %}<div class="ml-2 error-box grow">{{ form.email.errors }}</div>{% endif %}
+            </div>
+            <input name="{{ form.email.html_name }}" value="{{ form.email.value }}" class="w-full input-primary" placeholder="your@email.com">
+
+            <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 py-2">
+                <div class="flex items-center justify-between md:justify-start gap-2">
+                    <label for="id_is_staff" class="text-gray-800 flex flex-col">
+                        <span>{{ form.is_staff.label }}</span>
+                        <span class="text-sm text-gray-600">Can manage users and change site settings.</span>
+                    </label>
+                    <label class="inline-flex items-center cursor-pointer">
+                        <input name="{{ form.is_staff.html_name }}" id="id_is_staff" type="checkbox" class="sr-only peer"
+                               {% if form.is_staff.value %}checked{% endif %}
+                               {% if is_self %}disabled{% endif %}>
+                        <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-0.5 after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-sky-200 {% if is_self %}peer-disabled:opacity-50 peer-disabled:cursor-not-allowed{% endif %}"></div>
+                    </label>
+                    {% if is_self %}<span class="text-gray-500 text-sm">(Cannot change your own admin status)</span>{% endif %}
+                </div>
+
+                <div class="flex items-center justify-between md:justify-start gap-2">
+                    <label for="id_is_active" class="text-gray-800 flex flex-col">
+                        <span>{{ form.is_active.label }}</span>
+                        <span class="text-sm text-gray-600">Inactive users cannot log in.</span>
+                    </label>
+                    <label class="inline-flex items-center cursor-pointer">
+                        <input name="{{ form.is_active.html_name }}" id="id_is_active" type="checkbox" class="sr-only peer"
+                               {% if form.is_active.value %}checked{% endif %}
+                               {% if is_self %}disabled{% endif %}>
+                        <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:start-0.5 after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-sky-200 {% if is_self %}peer-disabled:opacity-50 peer-disabled:cursor-not-allowed{% endif %}"></div>
+                    </label>
+                    
+                    {% if is_self %}<span class="text-gray-500 text-sm">(Cannot deactivate yourself)</span>{% endif %}
+                    
+                </div>
+            </div>
+            <div class="flex justify-end py-2">
+                <input type="submit" value="Save Changes" class="btn-primary">
+            </div>
+        </form>
+    </div>
+
+    <div class="p-2 border-t-2 border-gray-400 mt-4">
+        {% if not is_self %}
+        <h2 class="text-gray-800 text-2xl font-medium mb-4">Actions</h2>
+        <div class="flex gap-2">
+            <button type="button" data-modal-target="reset-password-modal" data-modal-toggle="reset-password-modal" class="btn-primary">Reset Password</button>
+            <button type="button" data-modal-target="delete-user-modal" data-modal-toggle="delete-user-modal" class="btn-red ml-auto">Delete User</button>
+        </div>
+        {% else %}
+        <h2 class="text-gray-800 text-2xl font-medium mb-4">Change Your Password</h2>
+        <a href="{% url 'shifter_auth:settings' %}" class="btn-primary">Go to Settings</a>
+        {% endif %}
+    </div>
+
+    {% if not is_self %}
+    {# Reset Password Modal #}
+    <div id="reset-password-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-modal md:h-full">
+        <div class="bg-gray-400 opacity-50 fixed inset-0 z-40"></div>
+        <div class="relative w-full h-full max-w-2xl md:h-auto z-50">
+            <div class="relative bg-white rounded-lg shadow">
+                <div class="flex items-center justify-center p-4 border-b border-gray-200 rounded-t">
+                    <h3 class="text-xl font-semibold text-gray-900">
+                        Reset Password?
+                    </h3>
+                </div>
+                <div class="p-6 space-y-6">
+                    <p class="text-base leading-relaxed text-gray-600">
+                        Are you sure you want to reset the password for <strong>{{ object.email }}</strong>?
+                    </p>
+                    <p class="text-base leading-relaxed text-gray-600">
+                        A new temporary password will be generated and displayed. The user will be required to change it on their next login.
+                    </p>
+                </div>
+                <div class="flex flex-row-reverse p-6 space-x-2 border-t border-gray-200 rounded-b">
+                    <form method="post" action="{% url 'shifter_auth:user-reset-password' pk=object.pk %}">
+                        {% csrf_token %}
+                        <input type="submit" value="Reset Password" class="inline-flex justify-center m-2 text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 font-medium rounded-lg text-sm px-5 py-2.5 text-center cursor-pointer">
+                    </form>
+                    <button data-modal-toggle="reset-password-modal" type="button" class="inline-flex justify-center m-2 text-gray-900 bg-gray-200 hover:bg-gray-300 focus:ring-4 focus:outline-none focus:ring-primary rounded-lg border border-gray-200 text-sm font-medium px-5 py-2.5 hover:text-gray-900 focus:z-10 cursor-pointer">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if not is_self %}
+    {# Delete User Modal #}
+    <div id="delete-user-modal" tabindex="-1" aria-hidden="true" class="fixed top-0 left-0 right-0 z-50 hidden w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-modal md:h-full">
+        <div class="bg-gray-400 opacity-50 fixed inset-0 z-40"></div>
+        <div class="relative w-full h-full max-w-2xl md:h-auto z-50">
+            <div class="relative bg-white rounded-lg shadow">
+                <div class="flex items-center justify-center p-4 border-b border-gray-200 rounded-t">
+                    <h3 class="text-xl font-semibold text-gray-900">
+                        Delete User?
+                    </h3>
+                </div>
+                <div class="p-6 space-y-6">
+                    <p class="text-base leading-relaxed text-gray-600">
+                        Are you sure you want to delete <strong>{{ object.email }}</strong>?
+                    </p>
+                    <p class="text-base leading-relaxed text-gray-600">
+                        This will permanently delete the user account and expire all their uploaded files. This action cannot be undone.
+                    </p>
+                </div>
+                <div class="flex flex-row-reverse p-6 space-x-2 border-t border-gray-200 rounded-b">
+                    <form method="post" action="{% url 'shifter_auth:user-delete' pk=object.pk %}">
+                        {% csrf_token %}
+                        <input type="submit" value="Delete User" class="inline-flex justify-center m-2 text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 font-medium rounded-lg text-sm px-5 py-2.5 text-center cursor-pointer">
+                    </form>
+                    <button data-modal-toggle="delete-user-modal" type="button" class="inline-flex justify-center m-2 text-gray-900 bg-gray-200 hover:bg-gray-300 focus:ring-4 focus:outline-none focus:ring-primary rounded-lg border border-gray-200 text-sm font-medium px-5 py-2.5 hover:text-gray-900 focus:z-10 cursor-pointer">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/shifter/shifter_auth/templates/shifter_auth/user_list.html
+++ b/shifter/shifter_auth/templates/shifter_auth/user_list.html
@@ -1,0 +1,99 @@
+{% extends 'base.html' %}
+
+{% block title %}<title>Manage Users | Shifter</title>{% endblock %}
+
+{% block content %}
+<div class="standard-page-width">
+    <div class="py-2 rounded-t">
+        <h1 class="title">Manage Users</h1>
+    </div>
+    <div class="p-2">
+        {% if messages %}
+        <div class="mb-4">
+            {% for message in messages %}
+            <div class="flex info-box" role="alert" x-data="{ showFlashMessage: true }" x-cloak x-show="showFlashMessage">
+                <svg aria-hidden="true" class="shrink-0 w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
+                <span class="sr-only">Info</span>
+                <div class="ml-3 text-sm font-medium">
+                    {{ message }}
+                </div>
+                <button type="button" class="ml-auto -mx-1.5 -my-1.5 text-white rounded-lg focus:ring-2 focus:ring-blue-400 p-1.5 hover:bg-white hover:text-primary inline-flex h-8 w-8" aria-label="Close" @click="showFlashMessage = false">
+                    <span class="sr-only">Close</span>
+                    <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+                </button>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        <div class="flex justify-end">
+            <a href="{% url 'shifter_auth:create-new-user' %}" class="btn-primary">Create New User</a>
+        </div>
+        {% if total_users == 0 %}
+        <div class="text-center mt-16">
+            <p class="mb-4">No users found.</p>
+            <p><a class="btn-primary" href="{% url 'shifter_auth:create-new-user' %}">Register New User</a></p>
+        </div>
+        {% else %}
+        <form method="get" class="flex items-stretch flex-wrap justify-center mt-4 mb-4 gap-2">
+            {{ search_form.search }}
+            {% if request.GET.search %}
+            <a href="{% url 'shifter_auth:user-list' %}" class="btn-red">
+                <span class="sr-only">Close</span>
+                <svg aria-hidden="true" class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+            </a>
+            {% endif %}
+            <button type="submit" class="btn-primary">Search</button>
+        </form>
+        {% if object_list %}
+        <table class="table-auto w-full text-center">
+            <thead>
+                <tr class="border-b border-gray-200">
+                    <th class="py-2">Email</th>
+                    <th class="py-2 hidden md:table-cell">Admin</th>
+                    <th class="py-2 hidden md:table-cell">Active</th>
+                    <th class="py-2 hidden lg:table-cell">Active Files</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user in object_list %}
+                <tr class="hover:bg-slate-200 cursor-pointer" onclick="window.location='{% url 'shifter_auth:user-detail' pk=user.pk %}';">
+                    <td class="py-3">{{ user.email }}</td>
+                    <td class="py-3 hidden md:table-cell">{% if user.is_staff %}Yes{% else %}No{% endif %}</td>
+                    <td class="py-3 hidden md:table-cell">{% if user.is_active %}Yes{% else %}No{% endif %}</td>
+                    <td class="py-3 hidden lg:table-cell">{{ user.active_files_count }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <div class="text-center mt-16">
+            <p class="mb-4">No users found.</p>
+        </div>
+        {% endif %}
+        {% endif %}
+    </div>
+    {% if page_obj.paginator.num_pages > 1 %}
+        <div class="flex justify-center items-center mt-3">
+            {% if page_obj.has_previous %}
+                <a href="?page={{ page_obj.previous_page_number }}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}" class="flex w-fit self-center text-gray-100 whitespace-nowrap bg-primary p-2 mx-2 rounded-lg cursor-pointer">
+                    <svg class="text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12l4-4m-4 4 4 4"/>
+                    </svg>
+                </a>
+            {% endif %}
+
+            <span class="h-full">
+                Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+            </span>
+
+            {% if page_obj.has_next %}
+                <a href="?page={{ page_obj.next_page_number }}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}" class="flex w-fit self-center text-gray-100 whitespace-nowrap bg-primary p-2 mx-2 rounded-lg cursor-pointer">
+                    <svg class="text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 12H5m14 0-4 4m4-4-4-4"/>
+                    </svg>
+                </a>
+            {% endif %}
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/shifter/shifter_auth/templates/shifter_auth/user_password_reset_success.html
+++ b/shifter/shifter_auth/templates/shifter_auth/user_password_reset_success.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+
+{% block title %}<title>Password Reset | Shifter</title>{% endblock %}
+
+{% block content %}
+<div class="standard-page-width" x-data="{ showNotification: false, copyPassword() { navigator.clipboard.writeText('{{ new_password }}'); this.showNotification = true; setTimeout(() => { this.showNotification = false; }, 2000); } }">
+    <div class="py-2">
+        <h1 class="title">Password Reset</h1>
+    </div>
+    <div class="p-2">
+        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+            Password has been reset for <strong>{{ user_email }}</strong>.
+        </div>
+        <p class="text-gray-800 mb-4">The new temporary password is:</p>
+        <div class="flex items-center gap-2 mb-4">
+            <div class="bg-gray-100 p-4 rounded-lg text-center font-mono text-xl grow select-all">
+                {{ new_password }}
+            </div>
+            <button @click="copyPassword()" class="p-4 bg-gray-100 rounded-lg hover:bg-gray-200 cursor-pointer" title="Copy to clipboard">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+                </svg>
+            </button>
+        </div>
+        <p class="text-gray-600 mb-4">
+            Please share this password securely with the user. They will be required to change it upon their next login.
+        </p>
+        <a href="{% url 'shifter_auth:user-detail' pk=user_pk %}" class="btn-primary">Back to User</a>
+    </div>
+
+    <div x-show="showNotification" x-transition.opacity.duration.500ms class="fixed bottom-4 inset-x-0 flex justify-center" x-cloak>
+        <span class="bg-primary text-white p-4 rounded-lg">
+            Password copied to clipboard.
+        </span>
+    </div>
+</div>
+{% endblock %}

--- a/shifter/shifter_auth/tests.py
+++ b/shifter/shifter_auth/tests.py
@@ -1,11 +1,14 @@
 from django.contrib.auth import get_user, get_user_model
-from django.test import Client, RequestFactory, TestCase
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from shifter_auth.middleware import (
     ensure_first_time_setup_completed,
     is_first_time_setup_required,
 )
+from shifter_files.models import FileUpload
 
 TEST_USER_EMAIL = "iama@test.com"
 TEST_STAFF_USER_EMAIL = "iamastaff@test.com"
@@ -162,16 +165,24 @@ class CreateNewUserViewTest(TestCase):
             reverse("shifter_auth:create-new-user"),
             {
                 "email": TEST_ADDITIONAL_USER_EMAIL,
-                "password": TEST_USER_PASSWORD,
-                "confirm_password": TEST_USER_PASSWORD,
             },
         )
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("new_password", response.context)
 
         User = get_user_model()
         users = User.objects.filter(email=TEST_ADDITIONAL_USER_EMAIL)
         self.assertEqual(users.count(), 1)
         self.assertTrue(users[0].change_password_on_login)
+
+        # Verify the generated password works
+        new_password = response.context["new_password"]
+        client2 = Client()
+        self.assertTrue(
+            client2.login(
+                email=TEST_ADDITIONAL_USER_EMAIL, password=new_password
+            )
+        )
 
     def test_new_user_already_exists(self):
         client = Client()
@@ -180,8 +191,6 @@ class CreateNewUserViewTest(TestCase):
             reverse("shifter_auth:create-new-user"),
             {
                 "email": TEST_USER_EMAIL,
-                "password": TEST_USER_PASSWORD,
-                "confirm_password": TEST_USER_PASSWORD,
             },
         )
         self.assertEqual(response.status_code, 200)
@@ -190,25 +199,6 @@ class CreateNewUserViewTest(TestCase):
         User = get_user_model()
         self.assertEqual(User.objects.filter(email=TEST_USER_EMAIL).count(), 1)
 
-    def test_new_user_passwords_dont_match(self):
-        client = Client()
-        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
-        response = client.post(
-            reverse("shifter_auth:create-new-user"),
-            {
-                "email": TEST_ADDITIONAL_USER_EMAIL,
-                "password": TEST_USER_PASSWORD,
-                "confirm_password": TEST_USER_PASSWORD + "_wrong",
-            },
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertInHTML("Passwords do not match!", response.content.decode())
-
-        User = get_user_model()
-        self.assertEqual(
-            User.objects.filter(email=TEST_ADDITIONAL_USER_EMAIL).count(), 0
-        )
-
     def test_new_user_not_staff(self):
         client = Client()
         client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
@@ -216,8 +206,6 @@ class CreateNewUserViewTest(TestCase):
             reverse("shifter_auth:create-new-user"),
             {
                 "email": TEST_ADDITIONAL_USER_EMAIL,
-                "password": TEST_USER_PASSWORD,
-                "confirm_password": TEST_USER_PASSWORD,
             },
         )
         self.assertEqual(response.status_code, 403)
@@ -266,3 +254,458 @@ class FirstTimeSetupTest(TestCase):
         )
         response = middleware(request)
         self.assertIsNone(response)
+
+
+class UserListViewTest(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.regular_user = User.objects.create_user(
+            TEST_USER_EMAIL, TEST_USER_PASSWORD
+        )
+        self.staff_user = User.objects.create_user(
+            TEST_STAFF_USER_EMAIL, TEST_USER_PASSWORD, is_staff=True
+        )
+
+    def test_list_requires_login(self):
+        client = Client()
+        response = client.get(reverse("shifter_auth:user-list"))
+        self.assertEqual(response.status_code, 302)
+
+    def test_list_requires_staff(self):
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(reverse("shifter_auth:user-list"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_list_accessible_by_staff(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(reverse("shifter_auth:user-list"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_displays_users(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(reverse("shifter_auth:user-list"))
+        self.assertContains(response, TEST_USER_EMAIL)
+        self.assertContains(response, TEST_STAFF_USER_EMAIL)
+
+    def test_search_users(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(
+            reverse("shifter_auth:user-list") + "?search=iamastaff"
+        )
+        self.assertContains(response, TEST_STAFF_USER_EMAIL)
+        self.assertNotContains(response, TEST_USER_EMAIL)
+
+    @override_settings(MEDIA_ROOT="/tmp/test_media")
+    def test_list_shows_active_files_count(self):
+        """Test that user list displays count of active files."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        from shifter_files.models import FileUpload
+
+        # Create active files for regular user
+        for i in range(3):
+            file_content = SimpleUploadedFile(
+                f"test_file_{i}.txt",
+                b"Test content",
+                content_type="text/plain",
+            )
+            FileUpload.objects.create(
+                owner=self.regular_user,
+                filename=f"test_file_{i}.txt",
+                upload_datetime=timezone.now(),
+                expiry_datetime=timezone.now() + timezone.timedelta(days=7),
+                file_content=file_content,
+            )
+
+        # Create expired file for regular user (should not be counted)
+        expired_file = SimpleUploadedFile(
+            "expired.txt", b"Expired", content_type="text/plain"
+        )
+        FileUpload.objects.create(
+            owner=self.regular_user,
+            filename="expired.txt",
+            upload_datetime=timezone.now(),
+            expiry_datetime=timezone.now() - timezone.timedelta(days=1),
+            file_content=expired_file,
+        )
+
+        # Create 1 active file for staff user
+        staff_file = SimpleUploadedFile(
+            "staff.txt", b"Staff", content_type="text/plain"
+        )
+        FileUpload.objects.create(
+            owner=self.staff_user,
+            filename="staff.txt",
+            upload_datetime=timezone.now(),
+            expiry_datetime=timezone.now() + timezone.timedelta(days=7),
+            file_content=staff_file,
+        )
+
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(reverse("shifter_auth:user-list"))
+
+        # Verify response contains the active file counts
+        self.assertContains(response, "Active Files")
+        # Regular user should have 3 active files (not 4)
+        content = response.content.decode()
+        self.assertIn(">3<", content)
+        # Staff user should have 1 active file
+        self.assertIn(">1<", content)
+
+
+class UserDetailViewTest(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.regular_user = User.objects.create_user(
+            TEST_USER_EMAIL, TEST_USER_PASSWORD
+        )
+        self.staff_user = User.objects.create_user(
+            TEST_STAFF_USER_EMAIL, TEST_USER_PASSWORD, is_staff=True
+        )
+
+    def test_detail_requires_login(self):
+        client = Client()
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_detail_requires_staff(self):
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_detail_accessible_by_staff(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_edit_user_details(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.post(
+            url,
+            {
+                "email": "newemail@test.com",
+                "is_staff": False,
+                "is_active": True,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.regular_user.refresh_from_db()
+        self.assertEqual(self.regular_user.email, "newemail@test.com")
+
+    def test_cannot_remove_own_staff_status(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.staff_user.pk}
+        )
+        client.post(
+            url,
+            {
+                "email": TEST_STAFF_USER_EMAIL,
+                "is_staff": False,  # Trying to remove own staff status
+                "is_active": True,
+            },
+        )
+        self.staff_user.refresh_from_db()
+        self.assertTrue(self.staff_user.is_staff)  # Should still be staff
+
+    def test_toggle_user_admin_status(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+
+        # Make regular user an admin
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        client.post(
+            url,
+            {
+                "email": TEST_USER_EMAIL,
+                "is_staff": True,
+                "is_active": True,
+            },
+        )
+        self.regular_user.refresh_from_db()
+        self.assertTrue(self.regular_user.is_staff)
+
+    def test_reset_password_hidden_for_self(self):
+        """Test reset password button hidden for own account."""
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.staff_user.pk}
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # Verify "Reset Password" button is NOT present
+        self.assertNotIn("Reset Password", response.content.decode())
+
+        # Verify "Go to Settings" link IS present
+        self.assertIn("Go to Settings", response.content.decode())
+        self.assertIn("Change Your Password", response.content.decode())
+
+    def test_reset_password_shown_for_other_user(self):
+        """Test that reset password button is shown when viewing other user."""
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # Verify "Reset Password" button IS present
+        self.assertIn("Reset Password", response.content.decode())
+
+        # Verify "Delete User" button IS present
+        self.assertIn("Delete User", response.content.decode())
+
+        # Verify "Actions" header IS present
+        self.assertIn("Actions", response.content.decode())
+
+        # Verify settings link is NOT present
+        self.assertNotIn("Go to Settings", response.content.decode())
+        self.assertNotIn("Change Your Password", response.content.decode())
+
+    def test_user_detail_shows_help_text(self):
+        """Test that help text for toggles is displayed."""
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+        # Verify administrator help text
+        self.assertIn("Can manage users and change site settings", content)
+        # Verify active help text
+        self.assertIn("Inactive users cannot log in", content)
+
+
+class UserDeleteViewTest(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.regular_user = User.objects.create_user(
+            TEST_USER_EMAIL, TEST_USER_PASSWORD
+        )
+        self.staff_user = User.objects.create_user(
+            TEST_STAFF_USER_EMAIL, TEST_USER_PASSWORD, is_staff=True
+        )
+
+    def test_delete_requires_login(self):
+        client = Client()
+        url = reverse(
+            "shifter_auth:user-delete", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.post(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_delete_requires_staff(self):
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-delete", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.post(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_user(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-delete", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.post(url)
+        self.assertEqual(response.status_code, 302)
+        User = get_user_model()
+        self.assertFalse(User.objects.filter(pk=self.regular_user.pk).exists())
+
+    def test_cannot_delete_self(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-delete", kwargs={"pk": self.staff_user.pk}
+        )
+        response = client.post(url)
+        self.assertEqual(response.status_code, 302)
+        User = get_user_model()
+        self.assertTrue(User.objects.filter(pk=self.staff_user.pk).exists())
+
+    def test_get_not_allowed(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-delete", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 405)
+
+    @override_settings(MEDIA_ROOT="/tmp/test_media")
+    def test_delete_user_expires_files(self):
+        """Test that deleting a user sets their files to expired."""
+        # Create a file for the regular user
+        file_content = SimpleUploadedFile(
+            "test_file.txt", b"Test content", content_type="text/plain"
+        )
+        future_expiry = timezone.now() + timezone.timedelta(days=7)
+        file_upload = FileUpload.objects.create(
+            owner=self.regular_user,
+            filename="test_file.txt",
+            upload_datetime=timezone.now(),
+            expiry_datetime=future_expiry,
+            file_content=file_content,
+        )
+
+        # Verify file is not expired
+        self.assertFalse(file_upload.is_expired())
+
+        # Delete the user
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-delete", kwargs={"pk": self.regular_user.pk}
+        )
+        client.post(url)
+
+        # Refresh file from database
+        file_upload.refresh_from_db()
+
+        # Verify file is now expired
+        self.assertTrue(file_upload.is_expired())
+        self.assertLessEqual(file_upload.expiry_datetime, timezone.now())
+
+    @override_settings(MEDIA_ROOT="/tmp/test_media")
+    def test_deactivate_user_does_not_affect_files(self):
+        """Test that deactivating a user does NOT affect their files."""
+        # Create a file for the regular user
+        file_content = SimpleUploadedFile(
+            "test_file.txt", b"Test content", content_type="text/plain"
+        )
+        future_expiry = timezone.now() + timezone.timedelta(days=7)
+        file_upload = FileUpload.objects.create(
+            owner=self.regular_user,
+            filename="test_file.txt",
+            upload_datetime=timezone.now(),
+            expiry_datetime=future_expiry,
+            file_content=file_content,
+        )
+
+        # Verify file is not expired
+        self.assertFalse(file_upload.is_expired())
+        original_expiry = file_upload.expiry_datetime
+
+        # Deactivate the user
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        client.post(
+            url,
+            {
+                "email": TEST_USER_EMAIL,
+                "is_staff": False,
+                "is_active": False,  # Deactivate user
+            },
+        )
+
+        # Refresh file from database
+        file_upload.refresh_from_db()
+
+        # Verify file is still NOT expired and expiry hasn't changed
+        self.assertFalse(file_upload.is_expired())
+        self.assertEqual(file_upload.expiry_datetime, original_expiry)
+
+
+class UserResetPasswordViewTest(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.regular_user = User.objects.create_user(
+            TEST_USER_EMAIL, TEST_USER_PASSWORD
+        )
+        self.staff_user = User.objects.create_user(
+            TEST_STAFF_USER_EMAIL, TEST_USER_PASSWORD, is_staff=True
+        )
+
+    def test_reset_requires_login(self):
+        client = Client()
+        response = client.post(
+            reverse(
+                "shifter_auth:user-reset-password",
+                kwargs={"pk": self.regular_user.pk},
+            )
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_reset_requires_staff(self):
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.post(
+            reverse(
+                "shifter_auth:user-reset-password",
+                kwargs={"pk": self.regular_user.pk},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_reset_password(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.post(
+            reverse(
+                "shifter_auth:user-reset-password",
+                kwargs={"pk": self.regular_user.pk},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("new_password", response.context)
+
+        # Verify user must change password on login
+        self.regular_user.refresh_from_db()
+        self.assertTrue(self.regular_user.change_password_on_login)
+
+        # Verify old password no longer works
+        client2 = Client()
+        self.assertFalse(
+            client2.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        )
+
+        # Verify new password works
+        new_password = response.context["new_password"]
+        self.assertTrue(
+            client2.login(email=TEST_USER_EMAIL, password=new_password)
+        )
+
+    def test_get_not_allowed(self):
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(
+            reverse(
+                "shifter_auth:user-reset-password",
+                kwargs={"pk": self.regular_user.pk},
+            )
+        )
+        self.assertEqual(response.status_code, 405)

--- a/shifter/shifter_auth/urls.py
+++ b/shifter/shifter_auth/urls.py
@@ -5,6 +5,10 @@ from .views import (
     CreateNewUserView,
     FirstTimeSetupView,
     SettingsView,
+    UserDeleteView,
+    UserDetailView,
+    UserListView,
+    UserResetPasswordView,
     logoutView,
 )
 
@@ -22,4 +26,16 @@ urlpatterns = [
     path("settings", SettingsView.as_view(), name="settings"),
     path("new-user", CreateNewUserView.as_view(), name="create-new-user"),
     path("setup", FirstTimeSetupView.as_view(), name="first-time-setup"),
+    path("users", UserListView.as_view(), name="user-list"),
+    path("users/<int:pk>", UserDetailView.as_view(), name="user-detail"),
+    path(
+        "users/<int:pk>/delete",
+        UserDeleteView.as_view(),
+        name="user-delete",
+    ),
+    path(
+        "users/<int:pk>/reset-password",
+        UserResetPasswordView.as_view(),
+        name="user-reset-password",
+    ),
 ]

--- a/shifter/shifter_auth/views.py
+++ b/shifter/shifter_auth/views.py
@@ -1,13 +1,28 @@
+import secrets
+import string
+
 from django.contrib import messages
 from django.contrib.auth import get_user_model, login, logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.shortcuts import redirect
-from django.urls import reverse_lazy
+from django.db.models import Count, Q
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse, reverse_lazy
+from django.utils import timezone
+from django.views import View
 from django.views.decorators.http import require_POST
-from django.views.generic.edit import FormView
+from django.views.generic import ListView
+from django.views.generic.edit import FormView, UpdateView
 
-from .forms import ChangePasswordForm, NewUserForm
+from shifter_files.models import FileUpload
+
+from .forms import (
+    ChangePasswordForm,
+    CreateUserForm,
+    NewUserForm,
+    UserEditForm,
+    UserSearchForm,
+)
 from .middleware import is_first_time_setup_required
 
 
@@ -35,8 +50,7 @@ class SettingsView(LoginRequiredMixin, FormView):
 
 class CreateNewUserView(UserPassesTestMixin, FormView):
     template_name = "shifter_auth/new_user.html"
-    form_class = NewUserForm
-    success_url = reverse_lazy("shifter_files:index")
+    form_class = CreateUserForm
     permission_denied_message = (
         "You do not have access to create new users."
         " Please ask an administrator for assistance."
@@ -48,15 +62,24 @@ class CreateNewUserView(UserPassesTestMixin, FormView):
     def form_valid(self, form):
         User = get_user_model()
         email = form.cleaned_data["email"]
-        password = form.cleaned_data["password"]
+
+        # Generate a random password (12 characters, alphanumeric + special)
+        alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+        password = "".join(secrets.choice(alphabet) for _ in range(12))
+
         user = User.objects.create_user(email, password)
         user.change_password_on_login = True
         user.save()
-        messages.add_message(
-            self.request, messages.INFO, "User successfully created."
-        )
 
-        return super().form_valid(form)
+        return render(
+            self.request,
+            "shifter_auth/user_create_success.html",
+            {
+                "user_email": user.email,
+                "user_pk": user.pk,
+                "new_password": password,
+            },
+        )
 
 
 class FirstTimeSetupView(UserPassesTestMixin, FormView):
@@ -90,3 +113,143 @@ class FirstTimeSetupView(UserPassesTestMixin, FormView):
         login(self.request, user)
 
         return super().form_valid(form)
+
+
+class UserListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
+    """Display paginated list of all users with search functionality."""
+
+    model = get_user_model()
+    template_name = "shifter_auth/user_list.html"
+    paginate_by = 10
+    permission_denied_message = (
+        "You do not have permission to manage users. "
+        "Please ask an administrator for assistance."
+    )
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def get_queryset(self):
+        User = get_user_model()
+        queryset = (
+            User.objects.all()
+            .annotate(
+                active_files_count=Count(
+                    "fileupload",
+                    filter=Q(fileupload__expiry_datetime__gt=timezone.now()),
+                )
+            )
+            .order_by("email")
+        )
+
+        query = self.request.GET.get("search")
+        if query:
+            queryset = queryset.filter(Q(email__icontains=query))
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["search_form"] = UserSearchForm(self.request.GET)
+        context["total_users"] = get_user_model().objects.count()
+        return context
+
+
+class UserDetailView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+    """Display and edit user details."""
+
+    model = get_user_model()
+    template_name = "shifter_auth/user_detail.html"
+    form_class = UserEditForm
+    permission_denied_message = (
+        "You do not have permission to edit users. "
+        "Please ask an administrator for assistance."
+    )
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["editing_self"] = self.get_object().pk == self.request.user.pk
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_self"] = self.get_object().pk == self.request.user.pk
+        return context
+
+    def get_success_url(self):
+        messages.add_message(
+            self.request, messages.INFO, "User updated successfully."
+        )
+        return reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.object.pk}
+        )
+
+
+class UserDeleteView(LoginRequiredMixin, UserPassesTestMixin, View):
+    """Delete a user account."""
+
+    http_method_names = ["post"]
+    permission_denied_message = "You do not have permission to delete users."
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def post(self, request, pk):
+        User = get_user_model()
+        user_to_delete = get_object_or_404(User, pk=pk)
+
+        # Prevent self-deletion
+        if user_to_delete.pk == request.user.pk:
+            messages.add_message(
+                request, messages.ERROR, "You cannot delete your own account."
+            )
+            return redirect("shifter_auth:user-detail", pk=pk)
+
+        # Set all user's files to expired before deleting the user
+        FileUpload.objects.filter(owner=user_to_delete).update(
+            expiry_datetime=timezone.now()
+        )
+
+        email = user_to_delete.email
+        user_to_delete.delete()
+
+        messages.add_message(
+            request, messages.INFO, f"User {email} has been deleted."
+        )
+        return redirect("shifter_auth:user-list")
+
+
+class UserResetPasswordView(LoginRequiredMixin, UserPassesTestMixin, View):
+    """Reset a user's password to a random temporary password."""
+
+    http_method_names = ["post"]
+    permission_denied_message = (
+        "You do not have permission to reset passwords."
+    )
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def post(self, request, pk):
+        User = get_user_model()
+        user = get_object_or_404(User, pk=pk)
+
+        # Generate a random password (12 characters, alphanumeric + special)
+        alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+        new_password = "".join(secrets.choice(alphabet) for _ in range(12))
+
+        user.set_password(new_password)
+        user.change_password_on_login = True
+        user.save()
+
+        return render(
+            request,
+            "shifter_auth/user_password_reset_success.html",
+            {
+                "user_email": user.email,
+                "user_pk": user.pk,
+                "new_password": new_password,
+            },
+        )

--- a/shifter/templates/base.html
+++ b/shifter/templates/base.html
@@ -41,22 +41,22 @@
                         <li>
                             <a href="{% url 'shifter_auth:settings' %}" class="block py-2 px-4 rounded hover:bg-gray-100">Settings</a>
                         </li>
+                        {% if user.is_staff %}
                         <li>
-                            {% if user.is_staff %}
                             <button id="dropdownNavbarLink" data-dropdown-toggle="dropdownNavbar" class="flex py-2 px-4 w-full md:w-auto rounded hover:bg-gray-100 cursor-pointer">Admin <svg class="ml-1 my-auto w-5 h-5" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg></button>
                             {# Dropdown menu #}
                             <div id="dropdownNavbar" class="hidden z-10 w-44 font-normal bg-white rounded divide-y divide-gray-100" style="position: absolute; inset: 0px auto auto 0px; margin: 0px; transform: translate(0px, 10px);" data-popper-reference-hidden="" data-popper-escaped="" data-popper-placement="bottom">
                                 <ul class="py-1 text-sm text-gray-700" aria-labelledby="dropdownLargeButton">
                                     <li>
-                                        <a href="{% url 'shifter_auth:create-new-user' %}" class="block py-2 px-4 hover:bg-gray-100">Register New User</a>
+                                        <a href="{% url 'shifter_auth:user-list' %}" class="block py-2 px-4 hover:bg-gray-100">Manage Users</a>
                                     </li>
                                     <li>
                                         <a href="{% url 'shifter_site_settings:site-settings' %}" class="block py-2 px-4 hover:bg-gray-100">Site Settings</a>
                                     </li>
                                 </ul>
                             </div>
-                            {% endif %}
                         </li>
+                        {% endif %}
                         <li>
                             <form method="post" action="{% url 'shifter_auth:logout' %}">
                                 {% csrf_token %}


### PR DESCRIPTION
## Summary
Implements comprehensive user management functionality for admin users, addressing the requirements in #401.

## Features
- **User list view**: Paginated list of all users with search functionality and active file counts
- **User detail/edit**: Edit user email and staff status (prevents self-demotion)
- **Password reset**: Generate secure random passwords and force password change on next login
- **User deletion**: Delete users with automatic file expiration (prevents self-deletion)
- **Navigation**: Added "Manage Users" link to base template for staff users

## Implementation Details
- Auto-generated passwords use 12 characters with alphanumeric + special characters
- User deletion sets all owned files to expired before removing the user
- Search filters users by email
- Users annotated with active file count for quick overview
- Clear success pages display new passwords after creation/reset

## Test Plan
- [x] Staff users can access user management pages
- [x] Non-staff users are denied access
- [x] Search functionality works correctly
- [x] User creation generates secure passwords
- [x] Password reset works and forces password change
- [x] User deletion expires files and removes user
- [x] Self-deletion and self-demotion are prevented
- [x] Edit form validates email uniqueness

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)