### PR TITLE
feat: allow file downloads without password change requirement

### DIFF
--- a/shifter/shifter_auth/middleware.py
+++ b/shifter/shifter_auth/middleware.py
@@ -15,12 +15,21 @@ def ensure_password_changed(get_response):
         reverse(CHANGE_PASSWORD_URL)
     ]
 
+    # Allow file download paths (public downloads don't require password)
+    ALLOW_PATH_PREFIXES = ["/download/", "/f/"]
+
     def middleware(request):
         if not request.user.is_anonymous:
-            if (
-                request.user.change_password_on_login
-                and request.path not in ALLOW_LIST
-            ):
+            # Check if path is in allow list or starts with allowed prefix
+            path_allowed = (
+                request.path in ALLOW_LIST
+                or any(
+                    request.path.startswith(prefix)
+                    for prefix in ALLOW_PATH_PREFIXES
+                )
+            )
+
+            if request.user.change_password_on_login and not path_allowed:
                 return redirect(CHANGE_PASSWORD_URL)
 
         response = get_response(request)

--- a/shifter/shifter_auth/tests.py
+++ b/shifter/shifter_auth/tests.py
@@ -83,6 +83,26 @@ class EnsurePasswordResetMiddlewareTest(TestCase):
         response = client.get(reverse("shifter_auth:settings"))
         self.assertEqual(response.status_code, 200)
 
+    def test_allow_file_download_landing(self):
+        """Test that file download landing pages are accessible."""
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        # Use a fake hex - the middleware should allow it through
+        fake_hex = "a" * 32
+        response = client.get(f"/download/{fake_hex}")
+        # Should not redirect to password change (404 is fine)
+        self.assertNotEqual(response.status_code, 302)
+
+    def test_allow_direct_file_download(self):
+        """Test that direct file downloads are accessible."""
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        # Use a fake hex - the middleware should allow it through
+        fake_hex = "b" * 32
+        response = client.get(f"/f/{fake_hex}")
+        # Should not redirect to password change (404 is fine)
+        self.assertNotEqual(response.status_code, 302)
+
 
 class ChangePasswordViewTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- Enable file downloads for users with `change_password_on_login` flag set
- Users can now access shared files without being forced to change their password first
- Maintains security by only allowing public download paths

## Problem
Previously, users with temporary passwords (who have `change_password_on_login=True`) were redirected to the password change page when trying to access any path. This prevented them from downloading files that were shared with them, even though file downloads are public and don't require authentication.

## Solution
Updated the `ensure_password_changed` middleware to allow access to file download paths:
- `/download/<file_hex>` - Download landing pages (public)
- `/f/<file_hex>` - Direct file downloads (public)

## Changes
- **Middleware**: Added `ALLOW_PATH_PREFIXES` list for path prefix matching
- **Middleware**: Updated logic to check both exact paths and path prefixes
- **Tests**: Added 2 new tests verifying file download access

## Test plan
- [x] All 49 shifter_auth tests pass
- [x] Ruff linting passes
- [x] Users with change_password_on_login can access /download/ paths
- [x] Users with change_password_on_login can access /f/ paths
- [x] Users are still redirected for other protected paths
- [x] Logout and password change pages remain accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)