### PR TITLE
fix: admin nav disappears when editing non-admin user

### DIFF
--- a/shifter/shifter_auth/tests.py
+++ b/shifter/shifter_auth/tests.py
@@ -576,6 +576,22 @@ class UserDetailViewTest(TestCase):
         # Verify active help text
         self.assertIn("Inactive users cannot log in", content)
 
+    def test_admin_nav_visible_when_viewing_non_admin_user(self):
+        """Admin nav should remain visible when viewing non-admin."""
+        client = Client()
+        client.login(email=TEST_STAFF_USER_EMAIL, password=TEST_USER_PASSWORD)
+        url = reverse(
+            "shifter_auth:user-detail", kwargs={"pk": self.regular_user.pk}
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+        # Admin dropdown should be visible in nav
+        self.assertIn("Admin", content)
+        self.assertIn("Manage Users", content)
+        self.assertIn("Site Settings", content)
+
 
 class UserDeleteViewTest(TestCase):
     def setUp(self):

--- a/shifter/templates/base.html
+++ b/shifter/templates/base.html
@@ -28,7 +28,7 @@
                 <a href="{% url 'shifter_files:index' %}" class="flex items-center">
                     <img src="{% static 'img/logo-large.svg' %}" class="mr-3 w-32 md:w-40 lg:w-60" alt="Shifter Logo">
                 </a>
-                {% if user.is_authenticated %}
+                {% if request.user.is_authenticated %}
                 <button data-collapse-toggle="mobile-menu" type="button" class="inline-flex justify-center items-center ml-3 text-gray-400 rounded-lg md:hidden hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-300 cursor-pointer" aria-controls="mobile-menu-2" aria-expanded="false">
                 <span class="sr-only">Open main menu</span>
                 <svg class="w-6 h-6" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"></path></svg>
@@ -41,7 +41,7 @@
                         <li>
                             <a href="{% url 'shifter_auth:settings' %}" class="block py-2 px-4 rounded hover:bg-gray-100">Settings</a>
                         </li>
-                        {% if user.is_staff %}
+                        {% if request.user.is_staff %}
                         <li>
                             <button id="dropdownNavbarLink" data-dropdown-toggle="dropdownNavbar" class="flex py-2 px-4 w-full md:w-auto rounded hover:bg-gray-100 cursor-pointer">Admin <svg class="ml-1 my-auto w-5 h-5" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg></button>
                             {# Dropdown menu #}


### PR DESCRIPTION
## Summary
- Fix bug where Admin dropdown disappears when viewing non-admin user details
- Navigation bar now correctly checks logged-in user's staff status

## Problem
When an admin user navigated to the user detail page of a non-admin user, the Admin dropdown in the navigation bar would disappear. This made it impossible to access admin functions while editing other users.

## Root Cause
Django's `UpdateView` automatically adds the object being edited to the template context with the variable name based on the model. Since the model is `User`, it was added as `user`, which overrode the logged-in user variable that templates normally use.

The navigation bar was checking `{% if user.is_staff %}`, which now referred to the user being edited (non-admin) instead of the logged-in user (admin).

## Solution
Updated the navigation bar in `base.html` to use `request.user` instead of `user`:
- Changed `{% if user.is_authenticated %}` to `{% if request.user.is_authenticated %}`
- Changed `{% if user.is_staff %}` to `{% if request.user.is_staff %}`

This ensures the navigation always checks the logged-in user's permissions, not the object being viewed/edited.

## Changes
- **Template**: Updated base.html navigation to use `request.user`
- **Tests**: Added test verifying admin nav remains visible when viewing non-admin

## Test plan
- [x] All 50 shifter_auth tests pass (including 1 new test)
- [x] Ruff linting passes
- [x] Admin dropdown visible when viewing non-admin user
- [x] Admin dropdown visible when viewing admin user
- [x] Admin dropdown visible when editing own profile
- [x] No regressions in other views

🤖 Generated with [Claude Code](https://claude.com/claude-code)