### PR TITLE
fix: include files with no expiry date in active files count

### DIFF
--- a/shifter/shifter_auth/views.py
+++ b/shifter/shifter_auth/views.py
@@ -137,7 +137,8 @@ class UserListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
             .annotate(
                 active_files_count=Count(
                     "fileupload",
-                    filter=Q(fileupload__expiry_datetime__gt=timezone.now()),
+                    filter=Q(fileupload__expiry_datetime__gt=timezone.now())
+                    | Q(fileupload__expiry_datetime__isnull=True),
                 )
             )
             .order_by("email")


### PR DESCRIPTION
Fixed a bug in the UserListView where files with NULL expiry_datetime
were not being counted as active files. The query now includes both:
- Files with expiry_datetime > now (not yet expired)
- Files with expiry_datetime IS NULL (no expiration)

Added test case test_list_counts_files_with_no_expiry_date to verify
that files without expiration dates are properly counted.