### PR TITLE
feat: sort user list by creation date (oldest first)

### DIFF
--- a/shifter/shifter_auth/views.py
+++ b/shifter/shifter_auth/views.py
@@ -141,7 +141,7 @@ class UserListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
                     | Q(fileupload__expiry_datetime__isnull=True),
                 )
             )
-            .order_by("email")
+            .order_by("date_joined")
         )
 
         query = self.request.GET.get("search")


### PR DESCRIPTION
## Summary
- Changed user list sorting from email to creation date (oldest first)
- Users now appear in chronological order based on when their account was created

## Test plan
- [x] All existing tests pass
- [x] Ruff linting passes
- [x] User list view tests verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)