### PR TITLE
fix: prevent intermittent debug mode in CI tests

### DIFF
--- a/docker/dev/docker-compose.test.yml
+++ b/docker/dev/docker-compose.test.yml
@@ -11,6 +11,7 @@ services:
     env_file:
       - "../../.env EXAMPLE"
     environment:
+      - DEBUG=0
       - DJANGO_LOG_LEVEL=OFF
       - TEST_MODE=1
       - APP_VERSION=TESTING


### PR DESCRIPTION
## Summary
- Explicitly sets `DEBUG=0` in test Docker Compose environment
- Prevents intermittent debug mode activation during CI test runs

## Problem
Occasionally, GitHub Actions tests would run with debug mode enabled despite `DEBUG=0` being set in `.env EXAMPLE`. This was intermittent and retrying the tests without changes would fix it.

## Root Cause
The test compose file loaded environment variables from `.env EXAMPLE` (a file with a space in its name), but `DEBUG` was not explicitly set in the `environment:` section. Docker Compose could occasionally fail to parse the file correctly, or environment variables could be inherited from the GitHub Actions runner.

## Solution
Added `DEBUG=0` explicitly to the `environment:` section of the test compose file. Docker Compose's `environment:` section takes precedence over `env_file:`, ensuring `DEBUG` is always set correctly regardless of file parsing issues or host environment pollution.

## Test Plan
- [x] Tested locally
- [ ] Verify CI tests run with debug mode disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)