### PR TITLE
feat: add configurable upload and gunicorn timeouts

### DIFF
--- a/.env EXAMPLE
+++ b/.env EXAMPLE
@@ -8,6 +8,10 @@ DJANGO_LOG_LOCATION=/var/log/shifter.log
 TIMEZONE=UTC
 EXPIRED_FILE_CLEANUP_SCHEDULE=*/15 * * * *  # Cron schedule for cleaning up expired files. Default is every 15 minutes.
 
+### Timeout settings ###
+UPLOAD_TIMEOUT=300  # Upload timeout in seconds for the browser file upload (FilePond). Default is 300 (5 minutes).
+GUNICORN_TIMEOUT=600  # Gunicorn worker timeout in seconds. Default is 600 (10 minutes). Should be >= UPLOAD_TIMEOUT.
+
 ### Database settings ###
 DATABASE=sqlite  # Possible values: sqlite, postgres
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,4 +83,4 @@ ENV APP_VERSION=${APP_VERSION}
 RUN chown -R app:app $APP_HOME
 
 ENTRYPOINT [ "/home/app/web/entrypoint.sh" ]
-CMD [ "gunicorn", "shifter.wsgi:application", "--bind", "0.0.0.0:8000", "--timeout", "600" ]
+CMD ["sh", "-c", "exec gunicorn shifter.wsgi:application --bind 0.0.0.0:8000 --timeout ${GUNICORN_TIMEOUT:-600}"]

--- a/shifter/assets/js/filepond.js
+++ b/shifter/assets/js/filepond.js
@@ -132,6 +132,7 @@ export function setupFilepond(
   filepondElementName,
   expiryDatetimeElementName,
   max_file_size,
+  upload_timeout,
 ) {
   const inputElement = document.getElementsByName(filepondElementName)[0];
 
@@ -152,7 +153,7 @@ export function setupFilepond(
             'input[name="csrfmiddlewaretoken"]',
           ).value,
         },
-        timeout: 300 * 1000, // 5 minutes
+        timeout: upload_timeout * 1000,
         ondata: (formData) => {
           // Check if expiry is enabled
           let enableExpiryCheckbox = document.querySelector(
@@ -328,13 +329,14 @@ function autoInitFilepond() {
     return;
   }
 
-  const { fileField, expiryField, maxSize } = host.dataset;
+  const { fileField, expiryField, maxSize, uploadTimeout } = host.dataset;
   if (!fileField || !expiryField || !maxSize) {
     console.warn("Filepond init skipped: missing data attributes.");
     return;
   }
 
-  setupFilepond(fileField, expiryField, maxSize);
+  const timeout = uploadTimeout ? Number(uploadTimeout) : 300;
+  setupFilepond(fileField, expiryField, maxSize, timeout);
 }
 
 if (document.readyState === "loading") {

--- a/shifter/shifter/settings.py
+++ b/shifter/shifter/settings.py
@@ -303,6 +303,10 @@ DJANGO_VITE_DEV_SERVER = "http://localhost:5173"
 DJANGO_VITE_ASSETS_PATH = BASE_DIR / "assets"
 DJANGO_VITE_MANIFEST_PATH = BASE_DIR / "static" / "manifest.json"
 
+# Timeout configuration
+UPLOAD_TIMEOUT = int(os.environ.get("UPLOAD_TIMEOUT", 300))  # seconds
+GUNICORN_TIMEOUT = int(os.environ.get("GUNICORN_TIMEOUT", 600))  # seconds
+
 # Environment information
 SHIFTER_VERSION = os.environ.get("APP_VERSION", "Unknown")
 PYTHON_VERSION = os.environ.get("PYTHON_VERSION", "Unknown")

--- a/shifter/shifter_files/templates/shifter_files/file_upload.html
+++ b/shifter/shifter_files/templates/shifter_files/file_upload.html
@@ -9,7 +9,7 @@
 {% block title %}<title>Upload File | Shifter</title>{% endblock %}
 
 {% block content %}
-<div class="standard-page-width" x-data data-filepond data-file-field="{{ form.file_content.name }}" data-expiry-field="{{ form.expiry_datetime.name }}" data-max-size="{{ setting_max_file_size }}">
+<div class="standard-page-width" x-data data-filepond data-file-field="{{ form.file_content.name }}" data-expiry-field="{{ form.expiry_datetime.name }}" data-max-size="{{ setting_max_file_size }}" data-upload-timeout="{{ setting_upload_timeout }}">
     <div class="py-2 rounded-t">
         <h1 class="title">Upload File</h1>
     </div>

--- a/shifter/shifter_files/tests/views/test_index_view.py
+++ b/shifter/shifter_files/tests/views/test_index_view.py
@@ -283,6 +283,37 @@ class IndexViewTest(TestCase):
         # Verify hashes are different
         self.assertNotEqual(file1.file_hash, file2.file_hash)
 
+    def test_context_contains_upload_timeout_default(self):
+        """Test that upload page context includes the default timeout."""
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(reverse("shifter_files:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("setting_upload_timeout", response.context)
+        self.assertEqual(
+            response.context["setting_upload_timeout"],
+            settings.UPLOAD_TIMEOUT,
+        )
+
+    @override_settings(UPLOAD_TIMEOUT=900)
+    def test_context_contains_custom_upload_timeout(self):
+        """Test that a custom UPLOAD_TIMEOUT is passed to context."""
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(reverse("shifter_files:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["setting_upload_timeout"], 900)
+
+    def test_upload_timeout_in_template(self):
+        """Test that the upload timeout is rendered in data attr."""
+        client = Client()
+        client.login(email=TEST_USER_EMAIL, password=TEST_USER_PASSWORD)
+        response = client.get(reverse("shifter_files:index"))
+        self.assertContains(
+            response,
+            f'data-upload-timeout="{settings.UPLOAD_TIMEOUT}"',
+        )
+
     def test_file_upload_hash_large_file(self):
         """Test that hash is calculated correctly for large files."""
         client = Client()

--- a/shifter/shifter_files/views.py
+++ b/shifter/shifter_files/views.py
@@ -57,6 +57,7 @@ class FileUploadView(LoginRequiredMixin, FormView):
         context["setting_max_file_size"] = SiteSetting.get_setting(
             "max_file_size"
         )
+        context["setting_upload_timeout"] = settings.UPLOAD_TIMEOUT
         return context
 
 


### PR DESCRIPTION
Add UPLOAD_TIMEOUT and GUNICORN_TIMEOUT environment variables to allow
users with slow storage to increase timeouts for large file uploads.

- UPLOAD_TIMEOUT (default: 300s) controls the FilePond client-side
  upload timeout, passed from Django settings through the template
  to the JavaScript via a data attribute
- GUNICORN_TIMEOUT (default: 600s) controls the Gunicorn worker
  timeout in the production Docker container

Helps mitigate #658 but does not close it.

https://claude.ai/code/session_01R2WpCDeZH3btUmgv1hWnaQ